### PR TITLE
fix sharness test for ipfs init output

### DIFF
--- a/test/t0020-init.sh
+++ b/test/t0020-init.sh
@@ -38,8 +38,7 @@ test_expect_success "ipfs init output looks good" '
 	echo "initializing ipfs node at $IPFS_DIR" >expected &&
 	echo "generating key pair...done" >>expected &&
 	echo "peer identity: $PEERID" >>expected &&
-	echo "" >> expected &&
-	echo "to get started, enter: ipfs cat $STARTHASH" >>expected &&
+	printf "\\n%s\\n" "to get started, enter: ipfs cat $STARTHASH" >>expected &&
 	test_cmp expected actual_init
 '
 

--- a/test/t0020-init.sh
+++ b/test/t0020-init.sh
@@ -38,7 +38,8 @@ test_expect_success "ipfs init output looks good" '
 	echo "initializing ipfs node at $IPFS_DIR" >expected &&
 	echo "generating key pair...done" >>expected &&
 	echo "peer identity: $PEERID" >>expected &&
-	echo "\nto get started, enter: ipfs cat $STARTHASH" >>expected &&
+	echo "" >> expected &&
+	echo "to get started, enter: ipfs cat $STARTHASH" >>expected &&
 	test_cmp expected actual_init
 '
 


### PR DESCRIPTION
This test was failing on my machine because the newline wasnt being parsed as a newline, it was being printed literally as '\n'. This oughta fix that