### PR TITLE
go-peerstream transports: muxado

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -98,6 +98,10 @@
 			"Rev": "221d034a558b4c21b0624b2a450c076913854a57"
 		},
 		{
+			"ImportPath": "github.com/inconshreveable/muxado",
+			"Rev": "f693c7e88ba316d1a0ae3e205e22a01aa3ec2848"
+		},
+		{
 			"ImportPath": "github.com/jbenet/go-base58",
 			"Rev": "568a28d73fd97651d3442392036a658b6976eed5"
 		},

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -137,7 +137,7 @@
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-peerstream",
-			"Rev": "c3ee65e805acc6a27036b9b892e0a95fc9769c3c"
+			"Rev": "3f8972989ecf7b99db5d718b7ff2e1bf31011d4f"
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-random",

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/LICENSE
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2013 Alan Shreve
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/README.md
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/README.md
@@ -1,0 +1,122 @@
+# muxado - Stream multiplexing for Go
+
+## What is stream multiplexing?
+Imagine you have a single stream (a bi-directional stream of bytes) like a TCP connection. Stream multiplexing
+is a method for enabling the transmission of multiple simultaneous streams over the one underlying transport stream.
+
+## What is muxado?
+muxado is an implementation of a stream multiplexing library in Go that can be layered on top of a net.Conn to multiplex that stream.
+muxado's protocol is not currently documented explicitly, but it is very nearly an implementation of the HTTP2
+framing layer with all of the HTTP-specific bits removed. It is heavily inspired by HTTP2, SPDY, and WebMUX.
+
+## How does it work?
+Simplifying, muxado chunks data sent over each multiplexed stream and transmits each piece
+as a "frame" over the transport stream. It then sends these frames,
+often interleaving data for multiple streams, to the remote side.
+The remote endpoint then reassembles the frames into distinct streams
+of data which are presented to the application layer.
+
+## What good is it anyways?
+A stream multiplexing library is a powerful tool for an application developer's toolbox which solves a number of problems:
+
+- It allows developers to implement asynchronous/pipelined protocols with ease. Instead of matching requests with responses in your protocols, just open a new stream for each request and communicate over that.
+- muxado can do application-level keep-alives and dead-session detection so that you don't have to write heartbeat code ever again.
+- You never need to build connection pools for services running your protocol. You can open as many independent, concurrent streams as you need without incurring any round-trip latency costs.
+- muxado allows the server to initiate new streams to clients which is normally very difficult without NAT-busting trickery.
+
+## Show me the code!
+As much as possible, the muxado library strives to look and feel just like the standard library's net package. Here's how you initiate a new client session:
+
+    sess, err := muxado.DialTLS("tcp", "example.com:1234", tlsConfig)
+    
+And a server:
+
+    l, err := muxado.ListenTLS("tcp", ":1234", tlsConfig))
+    for {
+        sess, err := l.Accept()
+        go handleSession(sess)
+    }
+
+Once you have a session, you can open new streams on it:
+
+    stream, err := sess.Open()
+
+And accept streams opened by the remote side:
+
+    stream, err := sess.Accept()
+
+Streams satisfy the net.Conn interface, so they're very familiar to work with:
+    
+    n, err := stream.Write(buf)
+    n, err = stream.Read(buf)
+    
+muxado sessions and streams implement the net.Listener and net.Conn interfaces (with a small shim), so you can use them with existing golang libraries!
+
+    sess, err := muxado.DialTLS("tcp", "example.com:1234", tlsConfig)
+    http.Serve(sess.NetListener(), handler)
+
+## A more extensive muxado client
+
+    // open a new session to a remote endpoint
+    sess, err := muxado.Dial("tcp", "example.com:1234")
+    if err != nil {
+	    panic(err)
+    }
+
+    // handle streams initiated by the server
+    go func() {
+	    for {
+		    stream, err := sess.Accept()
+		    if err != nil {
+			    panic(err)
+		    }
+
+		    go handleStream(stream)
+	    }
+    }()
+
+    // open new streams for application requests
+    for req := range requests {
+	    str, err := sess.Open()
+	    if err != nil {
+		    panic(err)
+	    }
+
+	    go func(stream muxado.Stream) {
+		    defer stream.Close()
+
+		    // send request
+		    if _, err = stream.Write(req.serialize()); err != nil {
+			    panic(err)
+		    }
+
+		    // read response
+		    if buf, err := ioutil.ReadAll(stream); err != nil {
+			    panic(err)
+		    }
+
+		    handleResponse(buf)
+	    }(str)
+    }
+
+## How did you build it?
+muxado is a modified implementation of the HTTP2 framing protocol with all of the HTTP-specific bits removed. It aims
+for simplicity in the protocol by removing everything that is not core to multiplexing streams. The muxado code
+is also built with the intention that its performance should be moderately good within the bounds of working in Go. As a result,
+muxado does contain some unidiomatic code.
+
+## API documentation
+API documentation is available on godoc.org:
+
+[muxado API documentation](https://godoc.org/github.com/inconshreveable/muxado)
+
+## What are its biggest drawbacks?
+Any stream-multiplexing library over TCP will suffer from head-of-line blocking if the next packet to service gets dropped.
+muxado is also a poor choice when sending large payloads and speed is a priority.
+It shines best when the application workload needs to quickly open a large number of small-payload streams.
+
+## Status
+Most of muxado's features are implemented (and tested!), but there are many that are still rough or could be improved. See the TODO file for suggestions on what needs to improve.
+
+## License
+Apache

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/TODO
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/TODO
@@ -1,0 +1,35 @@
+improve the formatting of the docs to look nice for godoc
+use a better example in the docs first before showing the clever integration with the net.Listener/net.Conn APIs
+Make all errors support Temporary() API so applications can better decide what to do
+Handle case of running out of stream ids + test
+writeFrame errors should kill the session, but only if it's not a timeout + test
+Short read should cause an error + test
+Decrement() in outBuffer needs to have deadline support
+
+Extensions:
+    Heartbeat extension needs tests
+    Make extensions a public API instead of a private API
+    Document how extensions work
+    Don't include any extensions by default
+
+heartbeat test
+Finish writing buffer tests
+Write stress test
+Write multi-frame write test
+More session tests
+More stream tests
+Write frame/transport tests - verify read correct type, verify unknown type causes error, verify ioerror is propogated
+Write frame/syn tests
+Write frame/goaway tests
+
+### Low priority:
+- Add the ability to differentiate stream errors which allow you to safely retry
+- Decide what to do if the application isn't handling its accepted streams fast enough. Refuse stream? Wait and block reading more frames?
+- Figure out whether to die with/without lock - in GoAway/OpenStream
+- Add priority APIs to stream
+- Add priority extension
+- Add Reset() stream API
+- Eliminate unlikely race on s.remoteDebug between handleFrame() and die()
+- Should writeFrame calls for rst/wndinc set the write deadline?
+- don't send reset if the stream is fully closed
+- include muxado pun somewhere in the docs

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/adaptor.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/adaptor.go
@@ -1,0 +1,54 @@
+package muxado
+
+import (
+	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto"
+	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame"
+)
+
+// streamAdaptor recasts the types of some function calls by the proto/Stream implementation
+// so that it satisfies the public interface
+type streamAdaptor struct {
+	proto.IStream
+}
+
+func (a *streamAdaptor) Id() StreamId {
+	return StreamId(a.IStream.Id())
+}
+
+func (a *streamAdaptor) StreamType() StreamType {
+	return StreamType(a.IStream.StreamType())
+}
+
+func (a *streamAdaptor) Session() Session {
+	return &sessionAdaptor{a.IStream.Session()}
+}
+
+// sessionAdaptor recasts the types of some function calls by the proto/Session implementation
+// so that it satisfies the public interface
+type sessionAdaptor struct {
+	proto.ISession
+}
+
+func (a *sessionAdaptor) Accept() (Stream, error) {
+	str, err := a.ISession.Accept()
+	return &streamAdaptor{str}, err
+}
+
+func (a *sessionAdaptor) Open() (Stream, error) {
+	str, err := a.ISession.Open()
+	return &streamAdaptor{str}, err
+}
+
+func (a *sessionAdaptor) OpenStream(priority StreamPriority, streamType StreamType, fin bool) (Stream, error) {
+	str, err := a.ISession.OpenStream(frame.StreamPriority(priority), frame.StreamType(streamType), fin)
+	return &streamAdaptor{str}, err
+}
+
+func (a *sessionAdaptor) GoAway(code ErrorCode, debug []byte) error {
+	return a.ISession.GoAway(frame.ErrorCode(code), debug)
+}
+
+func (a *sessionAdaptor) Wait() (ErrorCode, error, []byte) {
+	code, err, debug := a.ISession.Wait()
+	return ErrorCode(code), err, debug
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/client.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/client.go
@@ -1,0 +1,32 @@
+package muxado
+
+import (
+	"crypto/tls"
+	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto"
+	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/ext"
+	"net"
+)
+
+// Client returns a new muxado client-side connection using conn as the transport.
+func Client(conn net.Conn) Session {
+	return &sessionAdaptor{proto.NewSession(conn, proto.NewStream, true, []proto.Extension{ext.NewDefaultHeartbeat()})}
+}
+
+// Dial opens a new connection to the given network/address and then beings a muxado client session on it.
+func Dial(network, addr string) (sess Session, err error) {
+	conn, err := net.Dial(network, addr)
+	if err != nil {
+		return
+	}
+	return Client(conn), nil
+}
+
+// DialTLS opens a new TLS encrytped connection with the givent configuration
+// to the network/address and then beings a muxado client session on it.
+func DialTLS(network, addr string, tlsConfig *tls.Config) (sess Session, err error) {
+	conn, err := tls.Dial(network, addr, tlsConfig)
+	if err != nil {
+		return
+	}
+	return Client(conn), nil
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/doc.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/doc.go
@@ -1,0 +1,57 @@
+// muxado is an implementation of a general-purpose stream-multiplexing protocol.
+//
+// muxado allows clients applications to multiplex a single stream-oriented connection,
+// like a TCP connection, and communicate over many streams on top of it. muxado accomplishes
+// this by chunking data sent over each stream into frames and then reassembling the
+// frames and buffering the data before being passed up to the application
+// layer on the other side.
+//
+// muxado is very nearly an exact implementation of the HTTP2 framing layer while leaving out all
+// the HTTP-specific parts. It is heavily inspired by HTTP2/SPDY/WebMUX.
+//
+// muxado's documentation uses the following terms consistently for easier communication:
+// - "a transport" is an underlying stream (typically TCP) over which frames are sent between
+// endpoints
+// - "a stream" is any of the full-duplex byte-streams multiplexed over the transport
+// - "a session" refers to an instance of the muxado protocol running over a transport between
+// two endpoints
+//
+// Perhaps the best part of muxado is the interface exposed to client libraries. Since new
+// streams may be initiated by both sides at any time, a muxado.Session implements the net.Listener
+// interface (almost! Go unfortunately doesn't support covariant interface satisfaction so there's
+// a shim). Each muxado stream implements the net.Conn interface. This allows you to integrate
+// muxado into existing code which works with these interfaces (which is most Golang networking code)
+// with very little difficulty. Consider the following toy example. Here we'll initiate a new secure
+// connection to a server, and then ask it which application it wants via an HTTP request over a muxado stream
+// and then serve an entire HTTP application *to the server*.
+//
+//
+// 	sess, err := muxado.DialTLS("tcp", "example.com:1234", new(tls.Config))
+// 	client := &http.Client{Transport: &http.Transport{Dial: sess.NetDial}}
+// 	resp, err := client.Get("http://example.com/appchoice")
+// 	switch getChoice(resp.Body) {
+// 	case "foo":
+// 		http.Serve(sess.NetListener(), fooHandler)
+// 	case "bar":
+//		http.Serve(sess.NetListener(), barHandler)
+// 	}
+//
+//
+// In addition to enabling multiple streams over a single connection, muxado enables other
+// behaviors which can be useful to the application layer:
+// - Both sides of a muxado session may initiate new streams
+// - muxado can transparently run application-level heartbeats and timeout dead sessions
+// - When connections fail, muxado indicates to the application which streams may be safely retried
+// - muxado supports prioritizing streams to maximize useful throughput when bandwidth-constrained
+//
+// A few examples of what these capabilities might make muxado useful for:
+// - eliminating custom async/pipeling code for your protocols
+// - eliminating connection pools in your protocols
+// - eliminating custom NAT traversal logic for enabling server-initiated streams
+//
+// muxado has been tuned to be very performant within the limits of what you can expect of pure-Go code.
+// Some of muxado's code looks unidiomatic in the quest for better performance. (Locks over channels, never allocating
+// from the heap, etc). muxado will typically outperform TCP connections when rapidly initiating many new
+// streams with small payloads. When sending a large payload over a single stream, muxado's worst case, it can
+// be 2-3x slower and does not parallelize well.
+package muxado

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/interface.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/interface.go
@@ -1,0 +1,115 @@
+package muxado
+
+import (
+	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame"
+	"net"
+	"time"
+)
+
+type StreamId frame.StreamId
+type StreamPriority frame.StreamPriority
+type StreamType frame.StreamType
+type ErrorCode frame.ErrorCode
+
+// Stream is a full duplex stream-oriented connection that is multiplexed over a Session.
+// Stream implement the net.Conn inteface.
+type Stream interface {
+	// Write writes the bytes in the given buffer to the stream
+	Write([]byte) (int, error)
+
+	// Read reads the next bytes on the stream into the given buffer
+	Read([]byte) (int, error)
+
+	// Close closes the stream. It attempts to behave as Close does for a TCP conn in that it
+	// half-closes the stream for sending, and it will send an RST if any more data is received
+	// from the remote side.
+	Close() error
+
+	// SetDeadline sets a time after which future Read and Write operations will fail.
+	SetDeadline(time.Time) error
+
+	// SetReadDeadline sets a time after which future Read operations will fail.
+	SetReadDeadline(time.Time) error
+
+	// SetWriteDeadline sets a time after which future Write operations will fail.
+	SetWriteDeadline(time.Time) error
+
+	// HalfClose sends a data frame with a fin flag set to half-close the stream from the local side.
+	HalfClose([]byte) (int, error)
+
+	// Id returns the stream's id.
+	Id() StreamId
+
+	// StreamType returns the stream's type
+	StreamType() StreamType
+
+	// Session returns the session object this stream is running on.
+	Session() Session
+
+	// RemoteAddr returns the session transport's remote address.
+	RemoteAddr() net.Addr
+
+	// LocalAddr returns the session transport's local address.
+	LocalAddr() net.Addr
+}
+
+// Session multiplexes many Streams over a single underlying stream transport.
+// Both sides of a muxado session can open new Streams. Sessions can also accept
+// new streams from the remote side.
+//
+// A muxado Session implements the net.Listener interface, returning new Streams from the remote side.
+type Session interface {
+
+	// Open initiates a new stream on the session. It is equivalent to OpenStream(0, 0, false)
+	Open() (Stream, error)
+
+	// OpenStream initiates a new stream on the session. A caller can specify a stream's priority and an opaque stream type.
+	// Setting fin to true will cause the stream to be half-closed from the local side immediately upon creation.
+	OpenStream(priority StreamPriority, streamType StreamType, fin bool) (Stream, error)
+
+	// Accept returns the next stream initiated by the remote side
+	Accept() (Stream, error)
+
+	// Kill closes the underlying transport stream immediately.
+	//
+	// You SHOULD always perfer to call Close() instead so that the connection
+	// closes cleanly by sending a GoAway frame.
+	Kill() error
+
+	// Close instructs the session to close cleanly, sending a GoAway frame if one hasn't already been sent.
+	//
+	// This implementation does not "linger". Pending writes on streams may fail.
+	//
+	// You MAY call Close() more than once. Each time after
+	// the first, Close() will return an error.
+	Close() error
+
+	// GoAway instructs the other side of the connection to stop
+	// initiating new streams by sending a GoAway frame. Most clients
+	// will just call Close(), but you may want explicit control of this
+	// in order to facilitate clean shutdowns.
+	//
+	// You MAY call GoAway() more than once. Each time after the first,
+	// GoAway() will return an error.
+	GoAway(ErrorCode, []byte) error
+
+	// LocalAddr returns the local address of the transport stream over which the session is running.
+	LocalAddr() net.Addr
+
+	// RemoteAddr returns the address of the remote side of the transport stream over which the session is running.
+	RemoteAddr() net.Addr
+
+	// Wait blocks until the session has shutdown and returns the error code for session termination. It also
+	// returns the error that caused the session to terminate as well as any debug information sent in the GoAway
+	// frame by the remote side.
+	Wait() (code ErrorCode, err error, debug []byte)
+
+	// NetListener returns an adaptor object which allows this Session to be used as a net.Listener. The returned
+	// net.Listener returns new streams initiated by the remote side as net.Conn's when calling Accept().
+	NetListener() net.Listener
+
+	// NetDial is a function that implements the same API as net.Dial and can be used in place of it. Users should keep
+	// in mind that it is the same as a call to Open(). It ignores both arguments passed to it, always initiate a new stream
+	// to the remote side.
+	NetDial(_, _ string) (net.Conn, error)
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/buffer/circular.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/buffer/circular.go
@@ -1,0 +1,87 @@
+package buffer
+
+import (
+	"errors"
+	"io"
+)
+
+var (
+	FullError = errors.New("Buffer is full")
+)
+
+// Reads as much data
+func readInto(rd io.Reader, p []byte) (n int, err error) {
+	var nr int
+	for n < len(p) {
+		nr, err = rd.Read(p[n:])
+		n += nr
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// A circular buffer on top of a byte-array
+// NOTE: It does not implement the Write() method, it implements ReadFrom()
+// to avoid copies
+type Circular struct {
+	buf  []byte // the bytes
+	size int    // == len(buf)
+	head int    // index of the next byte to read
+	tail int    // index of the last byte available to read
+}
+
+// Returns a new circular buffer of the given size
+func NewCircular(size int) *Circular {
+	return &Circular{
+		buf:  make([]byte, size+1),
+		size: size + 1,
+	}
+}
+
+// Copy data from the given reader into the buffer
+// Any errors encountered while reading are returned EXCEPT io.EOF.
+// If the reader fills the buffer, it returns buffer.FullError
+func (c *Circular) ReadFrom(rd io.Reader) (n int, err error) {
+	// IF:
+	// [---H+++T--]
+	if c.tail >= c.head {
+		n, err = readInto(rd, c.buf[c.tail:])
+		c.tail = (c.tail + n) % c.size
+		if err == io.EOF {
+			return n, nil
+		} else if err != nil {
+			return
+		}
+	}
+
+	// NOW:
+	// [T---H++++] or [++T--H+++]
+	n2, err := readInto(rd, c.buf[c.tail:c.head])
+	n += n2
+	c.tail += n2
+	if err == nil {
+		err = FullError
+	} else if err == io.EOF {
+		err = nil
+	}
+	return
+}
+
+// Read data out of the buffer. This never fails but may
+// return n==0 if there is no data to be read
+func (c *Circular) Read(p []byte) (n int, err error) {
+	if c.head > c.tail {
+		n = copy(p, c.buf[c.head:])
+		c.head = (c.head + n) % c.size
+		if c.head != 0 {
+			return
+		}
+	}
+
+	n2 := copy(p[n:], c.buf[c.head:c.tail])
+	n += n2
+	c.head += n2
+	return
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/buffer/circular_test.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/buffer/circular_test.go
@@ -1,0 +1,234 @@
+package buffer
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+func incBuf(start, size int) []byte {
+	b := make([]byte, size)
+	for i := 0; i < size; i++ {
+		b[i] = byte((start + i) % 16)
+	}
+	return b
+}
+
+func testBuffer() *Circular {
+	c := NewCircular(15)
+	c.buf = incBuf(0, 16)
+	return c
+}
+
+func TestEmptyRead(t *testing.T) {
+	t.Parallel()
+
+	var p [1]byte
+	c := NewCircular(16)
+	n, err := c.Read(p[:])
+
+	if err != nil {
+		t.Fatalf("Error on read operation: %v")
+	}
+
+	if n != 0 {
+		t.Errorf("Read %d bytes, expected 0", n)
+	}
+}
+
+// Test Read: [H+++T---]
+func TestStartRead(t *testing.T) {
+	t.Parallel()
+
+	c := testBuffer()
+
+	readSize := 8
+	p := make([]byte, readSize+1)
+	c.tail = readSize
+	n, err := c.Read(p)
+
+	if err != nil {
+		t.Fatalf("Error while reading: %v", err)
+	}
+
+	if n != readSize {
+		t.Fatalf("Read expected %d bytes, got %d", readSize, n)
+	}
+
+	expected := incBuf(0, 8)
+	got := p[:readSize]
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("Wrong buffer values read. Expected %v, got %v", expected, got)
+	}
+}
+
+func TestMiddleRead(t *testing.T) {
+	t.Parallel()
+
+	c := testBuffer()
+	readSize := 8
+	p := make([]byte, readSize+1)
+	c.head = 4
+	c.tail = 12
+	n, err := c.Read(p)
+	if err != nil {
+		t.Fatalf("Error while reading: %v", err)
+	}
+
+	if n != readSize {
+		t.Fatalf("Read expected %d bytes, got %d", readSize)
+	}
+
+	expected := incBuf(4, 8)
+	got := p[:readSize]
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("Wrong buffer values read. Expected %v, got %v", expected, got)
+	}
+}
+
+func TestTwoReads(t *testing.T) {
+	t.Parallel()
+
+	c := testBuffer()
+	readSize := 4
+	p := make([]byte, readSize)
+	c.head = 4
+	c.tail = 12
+
+	for i := 0; i < 2; i++ {
+		n, err := c.Read(p)
+		if err != nil {
+			t.Fatalf("Error while reading: %v", err)
+		}
+
+		if n != readSize {
+			t.Fatalf("Wrong read size. Expected %d, got %d", readSize, n)
+		}
+
+		expected := incBuf(4+(4*i), 4)
+		if !reflect.DeepEqual(p, expected) {
+			t.Fatalf("Wrong buffer values for read #%d. Expected %v, got %v", i+1, expected, p)
+		}
+	}
+}
+
+func TestReadTailZero(t *testing.T) {
+	t.Parallel()
+
+	c := testBuffer()
+	readSize := 4
+	p := make([]byte, readSize*2)
+	c.head = 12
+	c.tail = 0
+
+	n, err := c.Read(p)
+	if err != nil {
+		t.Fatalf("Error while reading: %v", err)
+	}
+
+	if n != readSize {
+		t.Fatalf("Wrong read size. Expected %d, got %d", readSize, n)
+	}
+
+	expected := incBuf(12, 4)
+	got := p[:readSize]
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("Wrong buffer values for read. Expected %v, got %v", expected, got)
+	}
+}
+
+func TestReadWrap(t *testing.T) {
+	t.Parallel()
+
+	c := testBuffer()
+	readSize := 14
+	p := make([]byte, readSize*2)
+	c.head = 12
+	c.tail = 10
+
+	n, err := c.Read(p)
+	if err != nil {
+		t.Fatalf("Error while reading: %v", err)
+	}
+
+	if n != readSize {
+		t.Fatalf("Wrong read size. Expected %d, got %d", readSize, n)
+	}
+
+	expected := incBuf(12, readSize)
+	got := p[:readSize]
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("Wrong buffer values for read. Expected %v, got %v", expected, got)
+	}
+}
+
+func TestEmptyReadAfterExhaustion(t *testing.T) {
+	t.Parallel()
+
+	c := testBuffer()
+	readSize := 14
+	p := make([]byte, readSize*2)
+	c.head = 12
+	c.tail = 10
+
+	n, err := c.Read(p)
+	if err != nil {
+		t.Fatalf("Error while reading: %v", err)
+	}
+
+	if n != readSize {
+		t.Fatalf("Wrong read size. Expected %d, got %d", readSize, n)
+	}
+
+	expected := incBuf(12, readSize)
+	got := p[:readSize]
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("Wrong buffer values for read. Expected %v, got %v", expected, p)
+	}
+
+	n, err = c.Read(p)
+	if err != nil {
+		t.Fatalf("Error while reading: %v", err)
+	}
+
+	if n != 0 {
+		t.Fatalf("Wrong read size. Expected 0, got %d", n)
+	}
+}
+
+func TestWriteTooBig(t *testing.T) {
+	t.Parallel()
+
+	size := 16
+	p := bytes.NewBuffer(make([]byte, size+1))
+	c := NewCircular(size)
+
+	_, err := c.ReadFrom(p)
+	if err != FullError {
+		t.Errorf("Expected FULL error but got %v", err)
+	}
+}
+
+func TestWriteReadFullFromZero(t *testing.T) {
+	toWrite := incBuf(0, 16)
+	c := NewCircular(16)
+
+	n, err := c.ReadFrom(bytes.NewBuffer(toWrite))
+	if err != nil {
+		t.Fatalf("Error while writing: %v", err)
+	}
+
+	if n != 16 {
+		t.Fatalf("Wrong number of bytes written. Expceted 16, got %d", n)
+	}
+
+	p := make([]byte, 16)
+	n, err = c.Read(p)
+	if err != nil {
+		t.Fatalf("Error while reading: %v", err)
+	}
+
+	if n != 16 {
+		t.Fatalf("")
+	}
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/buffer/inbound.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/buffer/inbound.go
@@ -1,0 +1,160 @@
+package buffer
+
+import (
+	"errors"
+	"io"
+	"io/ioutil"
+	"sync"
+	"time"
+)
+
+var (
+	AlreadyClosed = errors.New("Buffer already closed")
+)
+
+// A specialized concurrent circular buffer intended to buffer a stream's inbound data with the following properties:
+// - Minimizes copies by skipping the buffer if a write occurs while a reader is waiting
+// - Provides a mechnaism to time out reads after a deadline
+// - Provides a mechanism to set an 'error' that will fail reads when the buffer is empty
+type waitingReader struct {
+	buf []byte
+	n   int
+}
+
+type Inbound struct {
+	*Circular
+	*sync.Cond
+	err error
+	waitingReader
+	deadline time.Time
+	timer    *time.Timer
+}
+
+func NewInbound(size int) *Inbound {
+	return &Inbound{
+		Circular: NewCircular(size),
+		Cond:     sync.NewCond(new(sync.Mutex)),
+	}
+}
+
+func (b *Inbound) SetDeadline(t time.Time) {
+	b.L.Lock()
+
+	// set the deadline
+	b.deadline = t
+
+	// how long until the deadline
+	delay := t.Sub(time.Now())
+
+	if b.timer != nil {
+		b.timer.Stop()
+	}
+
+	// after the delay, wake up waiters
+	b.timer = time.AfterFunc(delay, func() {
+		b.Broadcast()
+	})
+
+	b.L.Unlock()
+}
+
+func (b *Inbound) SetError(err error) {
+	b.L.Lock()
+	b.err = err
+	b.Broadcast()
+	b.L.Unlock()
+}
+
+func (b *Inbound) GetError() (err error) {
+	b.L.Lock()
+	err = b.err
+	b.L.Unlock()
+	return
+}
+
+func (b *Inbound) ReadFrom(rd io.Reader) (n int, err error) {
+	b.L.Lock()
+
+	if b.err != nil {
+		b.L.Unlock()
+		if _, err = ioutil.ReadAll(rd); err != nil {
+			return
+		}
+		return 0, AlreadyClosed
+	}
+
+	// write directly to a reader's buffer, if possible
+	if b.waitingReader.buf != nil {
+		b.waitingReader.n, err = readInto(rd, b.waitingReader.buf)
+		n += b.waitingReader.n
+		b.waitingReader.buf = nil
+		if err != nil {
+			if err == io.EOF {
+				// EOF is not an error
+				err = nil
+			}
+
+			b.Broadcast()
+			b.L.Unlock()
+			return
+		}
+	}
+
+	// write the rest to buffer
+	var writeN int
+	writeN, err = b.Circular.ReadFrom(rd)
+	n += writeN
+
+	b.Broadcast()
+	b.L.Unlock()
+	return
+}
+
+func (b *Inbound) Read(p []byte) (n int, err error) {
+	b.L.Lock()
+
+	var wait *waitingReader
+
+	for {
+		// we got a direct write to our buffer
+		if wait != nil && wait.n != 0 {
+			n = wait.n
+			break
+		}
+
+		// check for timeout
+		if !b.deadline.IsZero() {
+			if time.Now().After(b.deadline) {
+				err = errors.New("Read timeout")
+				break
+			}
+		}
+
+		// try to read from the buffer
+		n, _ = b.Circular.Read(p)
+
+		// successfully read some data
+		if n != 0 {
+			break
+		}
+
+		// there's an error
+		if b.err != nil {
+			err = b.err
+			break
+		}
+
+		// register for a direct write
+		if b.waitingReader.buf == nil {
+			wait = &b.waitingReader
+			wait.buf = p
+			wait.n = 0
+		}
+
+		// no data, wait
+		b.Wait()
+	}
+
+	b.L.Unlock()
+	return
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/buffer/outbound.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/buffer/outbound.go
@@ -1,0 +1,59 @@
+package buffer
+
+import (
+	"sync"
+)
+
+type Outbound struct {
+	val int
+	err error
+	*sync.Cond
+}
+
+func NewOutbound(size int) *Outbound {
+	return &Outbound{val: size, Cond: sync.NewCond(new(sync.Mutex))}
+}
+
+func (b *Outbound) Increment(inc int) {
+	b.L.Lock()
+	b.val += inc
+	b.Broadcast()
+	b.L.Unlock()
+}
+
+func (b *Outbound) SetError(err error) {
+	b.L.Lock()
+	b.err = err
+	b.Broadcast()
+	b.L.Unlock()
+}
+
+func (b *Outbound) Decrement(dec int) (ret int, err error) {
+	if dec == 0 {
+		return
+	}
+
+	b.L.Lock()
+	for {
+		if b.err != nil {
+			err = b.err
+			break
+		}
+
+		if b.val > 0 {
+			if dec > b.val {
+				ret = b.val
+				b.val = 0
+				break
+			} else {
+				b.val -= dec
+				ret = dec
+				break
+			}
+		} else {
+			b.Wait()
+		}
+	}
+	b.L.Unlock()
+	return
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/buffer/shared.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/buffer/shared.go
@@ -1,0 +1,10 @@
+package buffer
+
+func BothClosed(in *Inbound, out *Outbound) (closed bool) {
+	in.L.Lock()
+	out.L.Lock()
+	closed = (in.err != nil && out.err != nil)
+	out.L.Unlock()
+	in.L.Unlock()
+	return
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/ext/const.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/ext/const.go
@@ -1,0 +1,9 @@
+package ext
+
+import (
+	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto"
+)
+
+const (
+	heartbeatExtensionType = proto.MinExtensionType + iota
+)

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/ext/heartbeat.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/ext/heartbeat.go
@@ -1,0 +1,125 @@
+package ext
+
+// XXX: There's no logging around heartbeats - how can we do this in a way that is useful
+// as a library?
+//
+// XXX: When we close the session because of a lost heartbeat or because of an error in the
+// heartbeating, there is no way to tell that; a Session will just appear to stop working
+
+import (
+	"encoding/binary"
+	proto "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto"
+	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame"
+	"io"
+	"time"
+)
+
+const (
+	defaultHeartbeatInterval  = 3 * time.Second
+	defaultHeartbeatTolerance = 10 * time.Second
+)
+
+type Heartbeat struct {
+	sess   proto.ISession
+	accept proto.ExtAccept
+
+	mark      chan int
+	interval  time.Duration
+	tolerance time.Duration
+}
+
+func NewDefaultHeartbeat() *Heartbeat {
+	return NewHeartbeat(defaultHeartbeatInterval, defaultHeartbeatTolerance)
+}
+
+func NewHeartbeat(interval, tolerance time.Duration) *Heartbeat {
+	return &Heartbeat{
+		mark:      make(chan int),
+		interval:  interval,
+		tolerance: tolerance,
+	}
+}
+
+func (h *Heartbeat) Start(sess proto.ISession, accept proto.ExtAccept) frame.StreamType {
+	h.sess = sess
+	h.accept = accept
+	go h.respond()
+	go h.request()
+	go h.check()
+
+	return heartbeatExtensionType
+}
+
+func (h *Heartbeat) check() {
+	t := time.NewTimer(h.interval + h.tolerance)
+
+	for {
+		select {
+		case <-t.C:
+			// time out waiting for a response!
+			h.sess.Close()
+			return
+
+		case <-h.mark:
+			t.Reset(h.interval + h.tolerance)
+		}
+	}
+}
+
+func (h *Heartbeat) respond() {
+	// close the session on any errors
+	defer h.sess.Close()
+
+	stream, err := h.accept()
+	if err != nil {
+		return
+	}
+
+	// read the next heartbeat id and respond
+	buf := make([]byte, 4)
+	for {
+		_, err := io.ReadFull(stream, buf)
+		if err != nil {
+			return
+		}
+
+		_, err = stream.Write(buf)
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (h *Heartbeat) request() {
+	// close the session on any errors
+	defer h.sess.Close()
+
+	// request highest possible priority for heartbeats
+	priority := frame.StreamPriority(0x7FFFFFFF)
+	stream, err := h.sess.OpenStream(priority, heartbeatExtensionType, false)
+	if err != nil {
+		return
+	}
+
+	// send heartbeats and then check that we got them back
+	var id uint32
+	for {
+		time.Sleep(h.interval)
+
+		if err := binary.Write(stream, binary.BigEndian, id); err != nil {
+			return
+		}
+
+		var respId uint32
+		if err := binary.Read(stream, binary.BigEndian, &respId); err != nil {
+			return
+		}
+
+		if id != respId {
+			return
+		}
+
+		// record the time
+		h.mark <- 1
+	}
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/data.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/data.go
@@ -1,0 +1,68 @@
+package frame
+
+import (
+	"io"
+)
+
+const (
+	// data frames are actually longer, but they are variable length
+	dataFrameSize = headerSize
+)
+
+type RStreamData struct {
+	Header
+	fixed [dataFrameSize]byte
+
+	toRead io.LimitedReader // when reading, the underlying connection's io.Reader is handed up
+}
+
+func (f *RStreamData) Reader() io.Reader {
+	return &f.toRead
+}
+
+func (f *RStreamData) readFrom(d deserializer) (err error) {
+	// not using io.LimitReader to avoid a heap memory allocation in the hot path
+	f.toRead.R = d
+	f.toRead.N = int64(f.Length())
+	return
+}
+
+// WStreamData is a StreamData frame that you can write
+// It delivers opaque data on a stream to the application layer
+type WStreamData struct {
+	Header
+	fixed   [dataFrameSize]byte
+	toWrite []byte // when writing, you just pass a byte slice to write
+}
+
+func (f *WStreamData) writeTo(s serializer) (err error) {
+	if _, err = s.Write(f.fixed[:]); err != nil {
+		return err
+	}
+
+	if _, err = s.Write(f.toWrite); err != nil {
+		return err
+	}
+
+	return
+}
+
+func (f *WStreamData) Set(streamId StreamId, data []byte, fin bool) (err error) {
+	var flags flagsType
+	if fin {
+		flags.Set(flagFin)
+	}
+
+	if err = f.Header.SetAll(TypeStreamData, len(data), streamId, flags); err != nil {
+		return
+	}
+
+	f.toWrite = data
+	return
+}
+
+func NewWStreamData() (f *WStreamData) {
+	f = new(WStreamData)
+	f.Header = f.fixed[:headerSize]
+	return
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/data_test.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/data_test.go
@@ -1,0 +1,134 @@
+package frame
+
+import (
+	"bytes"
+	"io/ioutil"
+	"reflect"
+	"testing"
+)
+
+type fakeTrans struct {
+	*bytes.Buffer
+}
+
+func (c *fakeTrans) Close() error { return nil }
+
+func loadedTrans(p []byte) (*fakeTrans, *BasicTransport) {
+	trans := &fakeTrans{bytes.NewBuffer(p)}
+	return trans, NewBasicTransport(trans)
+}
+
+type DataTestParams struct {
+	streamId StreamId
+	data     []byte
+	fin      bool
+}
+
+func TestSerializeData(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		params   DataTestParams
+		expected []byte
+	}{
+		{
+			// test a generic data frame
+			DataTestParams{0x49a1bb00, []byte{0x00, 0x01, 0x02, 0x03, 0x04}, false},
+			[]byte{0x0, 0x5, 0x0, TypeStreamData, 0x49, 0xa1, 0xbb, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04},
+		},
+		{
+			// test a a frame with fin
+			DataTestParams{streamMask, []byte{0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00}, true},
+			[]byte{0x00, 0x10, flagFin, TypeStreamData, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00},
+		},
+		{
+			// test a zero-length frame
+			DataTestParams{0x0, []byte{}, false},
+			[]byte{0x0, 0x0, 0x0, TypeStreamData, 0x0, 0x0, 0x0, 0x0},
+		},
+	}
+
+	for _, tcase := range cases {
+		buf, trans := loadedTrans([]byte{})
+		var f *WStreamData = NewWStreamData()
+		if err := f.Set(tcase.params.streamId, tcase.params.data, tcase.params.fin); err != nil {
+			t.Fatalf("Error while setting params %v!", tcase.params)
+		}
+
+		if err := f.writeTo(trans); err != nil {
+			t.Fatalf("Error while writing %v!", tcase.params)
+		}
+
+		if !reflect.DeepEqual(tcase.expected, buf.Bytes()) {
+			t.Errorf("Failed to serialize STREAM_DATA, expected: %v got %v", tcase.expected, buf.Bytes())
+		}
+	}
+}
+
+func TestDeserializeData(t *testing.T) {
+	_, trans := loadedTrans([]byte{0x00, 0x10, flagFin, TypeStreamData, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00})
+
+	h := newHeader()
+	if err := h.readFrom(trans); err != nil {
+		t.Fatalf("Failed to read header")
+	}
+
+	var f RStreamData
+	f.Header = h
+	if err := f.readFrom(trans); err != nil {
+		t.Fatalf("Read failed with %v", err)
+	}
+
+	got, err := ioutil.ReadAll(f.Reader())
+	if err != nil {
+		t.Fatalf("Error %v while reading data", err)
+	}
+
+	expected := []byte{0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00}
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("Wrong bytes read from transport. Expected %v, got %v", expected, got)
+	}
+
+	if !f.Fin() {
+		t.Errorf("Fin flag was not deserialized")
+	}
+}
+
+func TestTooLongSerializeData(t *testing.T) {
+	t.Parallel()
+
+	var f *WStreamData = NewWStreamData()
+	if err := f.Set(0, make([]byte, lengthMask+1), true); err == nil {
+		t.Errorf("Expected error when setting too long buffer, got none.")
+	}
+}
+
+func TestLengthLimitationData(t *testing.T) {
+	dataLen := 0x4
+	_, trans := loadedTrans([]byte{0x00, byte(dataLen), 0x0, TypeStreamData, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00})
+
+	h := newHeader()
+	if err := h.readFrom(trans); err != nil {
+		t.Fatalf("Failed to read header")
+	}
+
+	var f RStreamData
+	f.Header = h
+	if err := f.readFrom(trans); err != nil {
+		t.Fatalf("Read failed with %v", err)
+	}
+
+	got, err := ioutil.ReadAll(f.Reader())
+	if err != nil {
+		t.Fatalf("Error %v while reading data", err)
+	}
+
+	if len(got) != dataLen {
+		t.Errorf("Read with wrong number of bytes, got %d expected %d", len(got), 4)
+	}
+
+	expected := []byte{0xFF, 0xEE, 0xDD, 0xCC}
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("Wrong bytes read from transport. Expected %v, got %v", expected, got)
+	}
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/debug.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/debug.go
@@ -1,0 +1,37 @@
+package frame
+
+import "fmt"
+import "io"
+
+type DebugTransport struct {
+	prefix string
+	*BasicTransport
+}
+
+func (t *DebugTransport) Write(buf []byte) (int, error) {
+	fmt.Printf("%v writes %d bytes: %x\n", t.prefix, len(buf), buf)
+	return t.BasicTransport.Write(buf)
+}
+
+func (t *DebugTransport) WriteFrame(frame WFrame) (err error) {
+	// each frame knows how to write iteself to the framer
+	return frame.writeTo(t)
+}
+
+func (t *DebugTransport) ReadFrame() (f RFrame, err error) {
+	f, err = t.BasicTransport.ReadFrame()
+
+	fmt.Printf("%v reads Header length: %v\n", t.prefix, t.Header.Length())
+	fmt.Printf("%v reads Header type: %v\n", t.prefix, t.Header.Type())
+	fmt.Printf("%v reads Header stream id: %v\n", t.prefix, t.Header.StreamId())
+	fmt.Printf("%v reads Header fin: %v\n", t.prefix, t.Header.Fin())
+	return
+}
+
+func NewDebugTransport(rwc io.ReadWriteCloser, prefix string) *DebugTransport {
+	trans := &DebugTransport{
+		prefix:         prefix,
+		BasicTransport: &BasicTransport{ReadWriteCloser: rwc, Header: make([]byte, headerSize)},
+	}
+	return trans
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/error.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/error.go
@@ -1,0 +1,25 @@
+package frame
+
+import (
+	"fmt"
+)
+
+const (
+	NoError = iota
+	ProtocolError
+	InternalError
+	FlowControlError
+	StreamClosed
+	FrameSizeError
+	RefusedStream
+	Cancel
+	NoSuchError
+)
+
+type FramingError struct {
+	error
+}
+
+func protoError(fmtstr string, args ...interface{}) FramingError {
+	return FramingError{fmt.Errorf(fmtstr, args...)}
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/goaway.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/goaway.go
@@ -1,0 +1,79 @@
+package frame
+
+import "io"
+
+const (
+	goAwayBodySize  = 8
+	goAwayFrameSize = headerSize + goAwayBodySize
+)
+
+// Instruct the remote side not to initiate new streams
+type RGoAway struct {
+	Header
+	body  [goAwayBodySize]byte
+	debug []byte
+}
+
+func (f *RGoAway) LastStreamId() StreamId {
+	return StreamId(order.Uint32(f.body[0:]) & streamMask)
+}
+
+func (f *RGoAway) ErrorCode() ErrorCode {
+	return ErrorCode(order.Uint32(f.body[4:]))
+}
+
+func (f *RGoAway) Debug() []byte {
+	return f.debug
+}
+
+func (f *RGoAway) readFrom(d deserializer) (err error) {
+	if _, err = io.ReadFull(d, f.body[:]); err != nil {
+		return
+	}
+
+	f.debug = make([]byte, f.Length()-goAwayBodySize)
+	if _, err = io.ReadFull(d, f.debug); err != nil {
+		return
+	}
+
+	return
+}
+
+type WGoAway struct {
+	Header
+	data  [goAwayFrameSize]byte
+	debug []byte
+}
+
+func (f *WGoAway) writeTo(s serializer) (err error) {
+	if _, err = s.Write(f.data[:]); err != nil {
+		return
+	}
+
+	if _, err = s.Write(f.debug); err != nil {
+		return
+	}
+
+	return
+}
+
+func (f *WGoAway) Set(lastStreamId StreamId, errorCode ErrorCode, debug []byte) (err error) {
+	if f.Header.SetAll(TypeGoAway, len(debug)+goAwayFrameSize, 0, 0); err != nil {
+		return
+	}
+
+	if lastStreamId > streamMask {
+		err = protoError("Related stream id %d is out of range", lastStreamId)
+		return
+	}
+
+	order.PutUint32(f.data[headerSize:], uint32(lastStreamId))
+	order.PutUint32(f.data[headerSize+4:], uint32(errorCode))
+	return
+}
+
+func NewWGoAway() (f *WGoAway) {
+	f = new(WGoAway)
+	f.Header = Header(f.data[:headerSize])
+	return
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/header.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/header.go
@@ -1,0 +1,85 @@
+package frame
+
+import "io"
+
+const (
+	headerSize = 8
+)
+
+type Header []byte
+
+func newHeader() Header {
+	return Header(make([]byte, headerSize))
+}
+
+func (b Header) readFrom(d deserializer) (err error) {
+	// read the header
+	if _, err = io.ReadFull(d, []byte(b)); err != nil {
+		return err
+	}
+	return
+}
+
+func (b Header) Length() uint16 {
+	return order.Uint16(b[:2]) & lengthMask
+}
+
+func (b Header) SetLength(length int) (err error) {
+	if length > lengthMask || length < 0 {
+		return protoError("Frame length %d out of range", length)
+	}
+
+	order.PutUint16(b[:2], uint16(length))
+	return
+}
+
+func (b Header) Type() FrameType {
+	return FrameType((b[3]) & typeMask)
+}
+
+func (b Header) SetType(t FrameType) (err error) {
+	b[3] = byte(t & typeMask)
+	return
+}
+
+func (b Header) StreamId() StreamId {
+	return StreamId(order.Uint32(b[4:]) & streamMask)
+}
+
+func (b Header) SetStreamId(streamId StreamId) (err error) {
+	if streamId > streamMask {
+		return protoError("Stream id %d out of range", streamId)
+	}
+
+	order.PutUint32(b[4:], uint32(streamId))
+	return
+}
+
+func (b Header) Flags() flagsType {
+	return flagsType(b[2])
+}
+
+func (b Header) SetFlags(fl flagsType) (err error) {
+	b[2] = byte(fl)
+	return
+}
+
+func (b Header) Fin() bool {
+	return b.Flags().IsSet(flagFin)
+}
+
+func (b Header) SetAll(ftype FrameType, length int, streamId StreamId, flags flagsType) (err error) {
+	if err = b.SetType(ftype); err != nil {
+		return
+	}
+	if err = b.SetLength(length); err != nil {
+		return
+	}
+	if err = b.SetStreamId(streamId); err != nil {
+		return
+	}
+	if err = b.SetFlags(flags); err != nil {
+		return
+	}
+	return
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/header_test.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/header_test.go
@@ -1,0 +1,279 @@
+package frame
+
+import (
+	"reflect"
+	"testing"
+)
+
+type HeaderParams struct {
+	ftype    FrameType
+	length   int
+	streamId StreamId
+	flags    flagsType
+}
+
+func (params *HeaderParams) checkDeserialize(t *testing.T, h Header) {
+	if h.Type() != params.ftype {
+		t.Errorf("Failed deserialization. Expected type %x, got: %x", params.ftype, h.Type())
+	}
+
+	if h.Length() != uint16(params.length) {
+		t.Errorf("Failed deserialization. Expected length %x, got: %x", params.length, h.Length())
+	}
+
+	if h.Flags() != params.flags {
+		t.Errorf("Failed deserialization. Expected flags %x, got: %x", params.flags, h.Flags())
+	}
+
+	if h.StreamId() != params.streamId {
+		t.Errorf("Failed deserialization. Expected stream id %x, got: %x", params.streamId, h.StreamId())
+	}
+}
+
+func TestHeaderSerialization(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		input          HeaderParams
+		expectedOutput []byte
+	}{
+		{
+			HeaderParams{
+				ftype:    TypeStreamRst,
+				length:   0x4,
+				streamId: 0x2843,
+				flags:    0,
+			},
+			[]byte{0, 0x4, 0, 0x2, 0, 0, 0x28, 0x43},
+		},
+		{
+			HeaderParams{
+				ftype:    0x1F,
+				length:   0x37BD,
+				streamId: 0x0,
+				flags:    0x9,
+			},
+			[]byte{0x37, 0xBD, 0x9, 0x1F, 0, 0, 0, 0},
+		},
+		{
+			HeaderParams{
+				ftype:    0,
+				length:   0,
+				streamId: 0,
+				flags:    0,
+			},
+			[]byte{0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			HeaderParams{
+				ftype:    typeMask,
+				length:   lengthMask,
+				streamId: streamMask,
+				flags:    flagsMask,
+			},
+			[]byte{0x3F, 0xFF, 0xFF, 0x1F, 0x7F, 0xFF, 0xFF, 0xFF},
+		},
+		{
+			HeaderParams{
+				ftype:    0x1e,
+				length:   0x1DAA,
+				streamId: 0x4F224719,
+				flags:    0x17,
+			},
+			[]byte{0x1D, 0xAA, 0x17, 0x1E, 0x4F, 0x22, 0x47, 0x19},
+		},
+	}
+
+	for _, test := range testCases {
+		var h Header = Header(make([]byte, headerSize))
+		h.SetAll(test.input.ftype, test.input.length, test.input.streamId, test.input.flags)
+		output := []byte(h)
+		if !reflect.DeepEqual(output, test.expectedOutput) {
+			t.Errorf("Failed serialization of %v. Expected %x, got: %x", test.input, output, test.expectedOutput)
+		}
+	}
+}
+
+func TestHeaderDeserialization(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		input          []byte
+		expectedOutput HeaderParams
+	}{
+		{
+			[]byte{0, 0x4, 0, 0x2, 0, 0, 0x28, 0x43},
+			HeaderParams{
+				ftype:    TypeStreamRst,
+				length:   0x4,
+				streamId: 0x2843,
+				flags:    0,
+			},
+		},
+		{
+			[]byte{0x37, 0xBD, 0x9, 0x1F, 0, 0, 0, 0},
+			HeaderParams{
+				ftype:    0x1F,
+				length:   0x37BD,
+				streamId: 0x0,
+				flags:    0x9,
+			},
+		},
+		{
+			[]byte{0, 0, 0, 0, 0, 0, 0, 0},
+			HeaderParams{
+				ftype:    0,
+				length:   0,
+				streamId: 0,
+				flags:    0,
+			},
+		},
+		{
+			[]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+			HeaderParams{
+				ftype:    typeMask,
+				length:   lengthMask,
+				streamId: streamMask,
+				flags:    flagsMask,
+			},
+		},
+		{
+			[]byte{0x9D, 0xAA, 0x17, 0xF0, 0xCF, 0x22, 0x47, 0x19},
+			HeaderParams{
+				ftype:    0x10,
+				length:   0x1DAA,
+				streamId: 0x4F224719,
+				flags:    0x17,
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		test.expectedOutput.checkDeserialize(t, Header(test.input))
+
+	}
+}
+
+func TestHeaderRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	headers := []HeaderParams{
+		HeaderParams{
+			ftype:    TypeStreamRst,
+			length:   0x4,
+			streamId: 0x2843,
+			flags:    0,
+		},
+		HeaderParams{
+			ftype:    0x1F,
+			length:   0x37BD,
+			streamId: 0x0,
+			flags:    0x9,
+		},
+		HeaderParams{
+			ftype:    0,
+			length:   0,
+			streamId: 0,
+			flags:    0,
+		},
+		HeaderParams{
+			ftype:    typeMask,
+			length:   lengthMask,
+			streamId: streamMask,
+			flags:    flagsMask,
+		},
+		HeaderParams{
+			ftype:    0x1e,
+			length:   0x1DAA,
+			streamId: 0x4F224719,
+			flags:    0x17,
+		},
+	}
+
+	for _, input := range headers {
+		var h Header = Header(make([]byte, headerSize))
+		h.SetAll(input.ftype, input.length, input.streamId, input.flags)
+		input.checkDeserialize(t, h)
+	}
+}
+
+func TestValidStreamIds(t *testing.T) {
+	t.Parallel()
+
+	validStreamIds := []StreamId{
+		0x0,
+		0xFF,
+		0x23C10A8F,
+		0x7FFFFFFF,
+	}
+
+	for _, validStreamId := range validStreamIds {
+		var h Header = Header(make([]byte, headerSize))
+		err := h.SetAll(TypeStreamSyn, 0, validStreamId, 0)
+		if err != nil {
+			t.Errorf("Failed to create frame header with valid stream id %d.", validStreamId)
+		}
+
+	}
+}
+
+func TestInvalidStreamId(t *testing.T) {
+	t.Parallel()
+
+	invalidStreamIds := []StreamId{
+		0xF0000000,
+		0xB012CA8E,
+		0x80000000,
+		0xFFFFFFFF,
+	}
+
+	for _, invalidStreamId := range invalidStreamIds {
+		var h Header = Header(make([]byte, headerSize))
+		err := h.SetAll(TypeStreamSyn, 0, invalidStreamId, 0)
+		if err == nil {
+			t.Errorf("Failed to error on invalid stream id %d.", invalidStreamId)
+		}
+
+	}
+}
+
+func TestValidLengths(t *testing.T) {
+	t.Parallel()
+
+	validLengths := []int{
+		0x0,
+		0x2FF,
+		0x301A,
+		0x3FFF,
+	}
+
+	for _, validLength := range validLengths {
+		var h Header = Header(make([]byte, headerSize))
+		err := h.SetAll(TypeStreamSyn, validLength, 0, 0)
+		if err != nil {
+			t.Errorf("Failed to create frame header with valid length %d.", validLength)
+		}
+
+	}
+}
+
+func TestInvalidLengths(t *testing.T) {
+	t.Parallel()
+
+	invalidLengths := []int{
+		-1,
+		0x4000,
+		0xB012,
+		0x8000,
+		0xFFFF,
+	}
+
+	for _, invalidLength := range invalidLengths {
+		var h Header = Header(make([]byte, headerSize))
+		err := h.SetAll(TypeStreamSyn, invalidLength, 0, 0)
+		if err == nil {
+			t.Errorf("Failed to error on invalid length %d.", invalidLength)
+		}
+
+	}
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/interface.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/interface.go
@@ -1,0 +1,25 @@
+package frame
+
+import (
+	"io"
+)
+
+type Transport interface {
+	WriteFrame(WFrame) error
+	ReadFrame() (RFrame, error)
+	Close() error
+}
+
+// A frame can read and write itself to a serializer/deserializer
+type RFrame interface {
+	StreamId() StreamId
+	Type() FrameType
+	readFrom(deserializer) error
+}
+
+type WFrame interface {
+	writeTo(serializer) error
+}
+
+type deserializer io.Reader
+type serializer io.Writer

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/rst.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/rst.go
@@ -1,0 +1,67 @@
+package frame
+
+import "io"
+
+const (
+	rstBodySize  = 4
+	rstFrameSize = headerSize + rstBodySize
+)
+
+// RsStreamRst is a STREAM_RST frame that is read from a transport
+type RStreamRst struct {
+	Header
+	body [rstBodySize]byte
+}
+
+func (f *RStreamRst) readFrom(d deserializer) (err error) {
+	if f.Length() != rstBodySize {
+		return protoError("STREAM_RST length must be %d, got %d", rstBodySize, f.Length())
+	}
+
+	if _, err = io.ReadFull(d, f.body[:]); err != nil {
+		return
+	}
+
+	return
+}
+
+func (f *RStreamRst) ErrorCode() ErrorCode {
+	return ErrorCode(order.Uint32(f.body[0:]))
+}
+
+// WStreamRst is a STREAM_RST frame that can be written, it terminate a stream ungracefully
+type WStreamRst struct {
+	Header
+	all [rstFrameSize]byte
+}
+
+func NewWStreamRst() (f *WStreamRst) {
+	f = new(WStreamRst)
+	f.Header = Header(f.all[:headerSize])
+	return
+}
+
+func (f *WStreamRst) writeTo(s serializer) (err error) {
+	_, err = s.Write(f.all[:])
+	return
+}
+
+func (f *WStreamRst) Set(streamId StreamId, errorCode ErrorCode) (err error) {
+	if err = f.Header.SetAll(TypeStreamRst, rstBodySize, streamId, 0); err != nil {
+		return
+	}
+
+	if err = validRstErrorCode(errorCode); err != nil {
+		return
+	}
+
+	order.PutUint32(f.all[headerSize:], uint32(errorCode))
+	return
+}
+
+func validRstErrorCode(errorCode ErrorCode) error {
+	if errorCode >= NoSuchError {
+		return protoError("Invalid error code %d for STREAM_RST", errorCode)
+	}
+	return nil
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/rst_test.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/rst_test.go
@@ -1,0 +1,101 @@
+package frame
+
+import (
+	"reflect"
+	"testing"
+)
+
+type RstTestParams struct {
+	streamId  StreamId
+	errorCode ErrorCode
+}
+
+func TestSerializeRst(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		params   RstTestParams
+		expected []byte
+	}{
+		{
+			RstTestParams{0x49a1bb00, ProtocolError},
+			[]byte{0x0, 0x4, 0x0, TypeStreamRst, 0x49, 0xa1, 0xbb, 0x00, 0x0, 0x0, 0x0, ProtocolError},
+		},
+		{
+			RstTestParams{0x0, FlowControlError},
+			[]byte{0x0, 0x4, 0x0, TypeStreamRst, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, FlowControlError},
+		},
+		{
+			RstTestParams{streamMask, RefusedStream},
+			[]byte{0x00, 0x4, 0x0, TypeStreamRst, 0x7F, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, RefusedStream},
+		},
+	}
+
+	for _, tcase := range cases {
+		buf, trans := loadedTrans([]byte{})
+		var f *WStreamRst = NewWStreamRst()
+
+		if err := f.Set(tcase.params.streamId, tcase.params.errorCode); err != nil {
+			t.Fatalf("Error while setting params %v!", tcase.params)
+		}
+
+		if err := f.writeTo(trans); err != nil {
+			t.Fatalf("Error while writing %v!", tcase.params)
+		}
+
+		if !reflect.DeepEqual(tcase.expected, buf.Bytes()) {
+			t.Errorf("Failed to serialize STREAM_RST, expected: %v got %v", tcase.expected, buf.Bytes())
+		}
+	}
+}
+
+func TestDeserializeRst(t *testing.T) {
+	t.Parallel()
+
+	_, trans := loadedTrans([]byte{0x00, rstBodySize, 0x0, TypeStreamRst, 0x7F, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, RefusedStream})
+	h := newHeader()
+	if err := h.readFrom(trans); err != nil {
+		t.Fatalf("Failed to read header: %v", err)
+	}
+	var f RStreamRst
+	f.Header = h
+	if err := f.readFrom(trans); err != nil {
+		t.Fatalf("Error while reading rst frame: %v", err)
+	}
+
+	if f.ErrorCode() != RefusedStream {
+		t.Errorf("Expected error code %d but got %d", RefusedStream, f.ErrorCode())
+	}
+}
+
+// test a bad frame length of rstBodySize+1
+func TestBadLengthRst(t *testing.T) {
+	t.Parallel()
+
+	_, trans := loadedTrans([]byte{0x00, rstBodySize + 1, 0x0, TypeStreamRst, 0x7F, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x0})
+	h := newHeader()
+	if err := h.readFrom(trans); err != nil {
+		t.Fatalf("Failed to read header: %v", err)
+	}
+	var f RStreamRst
+	f.Header = h
+	if err := f.readFrom(trans); err == nil {
+		t.Errorf("Expected error when setting bad rst frame length, got none.")
+	}
+}
+
+// test fewer than rstBodySize bytes available after header
+func TestShortReadRst(t *testing.T) {
+	t.Parallel()
+
+	_, trans := loadedTrans([]byte{0x00, rstBodySize, 0x0, TypeStreamRst, 0x7F, 0xFF, 0xFF, 0xFF, 0x1})
+	h := newHeader()
+	if err := h.readFrom(trans); err != nil {
+		t.Fatalf("Failed to read header: %v", err)
+	}
+	var f RStreamRst
+	f.Header = h
+	if err := f.readFrom(trans); err == nil {
+		t.Errorf("Expected error when reading incomplete frame, got none.")
+	}
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/syn.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/syn.go
@@ -1,0 +1,120 @@
+package frame
+
+import (
+	"fmt"
+	"io"
+)
+
+const (
+	maxSynBodySize  = 8
+	maxSynFrameSize = headerSize + maxSynBodySize
+)
+
+type RStreamSyn struct {
+	Header
+	body           [maxSynBodySize]byte
+	streamPriority StreamPriority
+	streamType     StreamType
+}
+
+// StreamType returns the stream's defined type as specified by
+// the remote endpoint
+func (f *RStreamSyn) StreamType() StreamType {
+	return f.streamType
+}
+
+// StreamPriority returns the stream priority set on this frame
+func (f *RStreamSyn) StreamPriority() StreamPriority {
+	return f.streamPriority
+}
+
+func (f *RStreamSyn) parseFields() error {
+	var length uint16 = 0
+	flags := f.Flags()
+
+	if flags.IsSet(flagStreamPriority) {
+		f.streamPriority = StreamPriority(order.Uint32(f.body[length : length+4]))
+		length += 4
+	} else {
+		f.streamPriority = 0
+	}
+
+	if flags.IsSet(flagStreamType) {
+		f.streamType = StreamType(order.Uint32(f.body[length : length+4]))
+		length += 4
+	} else {
+		f.streamType = 0
+	}
+
+	if length != f.Length() {
+		return fmt.Errorf("Expected length %d for flags %v, but got %v", length, flags, f.Length())
+	}
+
+	return nil
+}
+
+func (f *RStreamSyn) readFrom(d deserializer) (err error) {
+	if _, err = io.ReadFull(d, f.body[:f.Length()]); err != nil {
+		return
+	}
+
+	if err = f.parseFields(); err != nil {
+		return
+	}
+
+	return
+}
+
+type WStreamSyn struct {
+	Header
+	data   [maxSynFrameSize]byte
+	length int
+}
+
+func (f *WStreamSyn) writeTo(s serializer) (err error) {
+	_, err = s.Write(f.data[:headerSize+f.Length()])
+	return
+}
+
+func (f *WStreamSyn) Set(streamId StreamId, streamPriority StreamPriority, streamType StreamType, fin bool) (err error) {
+	var (
+		flags  flagsType
+		length int = 0
+	)
+
+	// set fin bit
+	if fin {
+		flags.Set(flagFin)
+	}
+
+	if streamPriority != 0 {
+		if streamPriority > priorityMask {
+			err = protoError("Priority %d is out of range", streamPriority)
+			return
+		}
+
+		flags.Set(flagStreamPriority)
+		start := headerSize + length
+		order.PutUint32(f.data[start:start+4], uint32(streamPriority))
+		length += 4
+	}
+
+	if streamType != 0 {
+		flags.Set(flagStreamType)
+		start := headerSize + length
+		order.PutUint32(f.data[start:start+4], uint32(streamType))
+		length += 4
+	}
+
+	// make the frame
+	if err = f.Header.SetAll(TypeStreamSyn, length, streamId, flags); err != nil {
+		return
+	}
+	return
+}
+
+func NewWStreamSyn() (f *WStreamSyn) {
+	f = new(WStreamSyn)
+	f.Header = Header(f.data[:headerSize])
+	return
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/transport.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/transport.go
@@ -1,0 +1,79 @@
+package frame
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+var (
+	order = binary.BigEndian
+)
+
+// BasicTransport can serialize/deserialize frames on an underlying
+// net.Conn to implement the muxado protocol.
+type BasicTransport struct {
+	io.ReadWriteCloser
+	Header
+	RStreamSyn
+	RStreamRst
+	RStreamData
+	RStreamWndInc
+	RGoAway
+}
+
+// WriteFrame writes the given frame to the underlying transport
+func (t *BasicTransport) WriteFrame(frame WFrame) (err error) {
+	// each frame knows how to write iteself to the framer
+	err = frame.writeTo(t)
+	return
+}
+
+// ReadFrame reads the next frame from the underlying transport
+func (t *BasicTransport) ReadFrame() (f RFrame, err error) {
+	// read the header
+	if _, err = io.ReadFull(t, []byte(t.Header)); err != nil {
+		return nil, err
+	}
+
+	switch t.Header.Type() {
+	case TypeStreamSyn:
+		frame := &t.RStreamSyn
+		frame.Header = t.Header
+		err = frame.readFrom(t)
+		return frame, err
+
+	case TypeStreamRst:
+		frame := &t.RStreamRst
+		frame.Header = t.Header
+		err = frame.readFrom(t)
+		return frame, err
+
+	case TypeStreamData:
+		frame := &t.RStreamData
+		frame.Header = t.Header
+		err = frame.readFrom(t)
+		return frame, err
+
+	case TypeStreamWndInc:
+		frame := &t.RStreamWndInc
+		frame.Header = t.Header
+		err = frame.readFrom(t)
+		return frame, err
+
+	case TypeGoAway:
+		frame := &t.RGoAway
+		frame.Header = t.Header
+		err = frame.readFrom(t)
+		return frame, err
+
+	default:
+		return nil, protoError("Illegal frame type: %d", t.Header.Type())
+	}
+
+	return
+}
+
+func NewBasicTransport(rwc io.ReadWriteCloser) *BasicTransport {
+	trans := &BasicTransport{ReadWriteCloser: rwc, Header: make([]byte, headerSize)}
+	return trans
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/types.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/types.go
@@ -1,0 +1,61 @@
+package frame
+
+const (
+	// offsets for packing/unpacking frames
+	lengthOffset = 32 + 16
+	flagsOffset  = 32 + 8
+	typeOffset   = 32 + 3
+
+	// masks for packing/unpacking frames
+	lengthMask   = 0x3FFF
+	streamMask   = 0x7FFFFFFF
+	flagsMask    = 0xFF
+	typeMask     = 0x1F
+	wndIncMask   = 0x7FFFFFFF
+	priorityMask = 0x7FFFFFFF
+)
+
+// a frameType is a 5-bit integer in the frame header that identifies the type of frame
+type FrameType uint8
+
+const (
+	TypeStreamSyn    = 0x1
+	TypeStreamRst    = 0x2
+	TypeStreamData   = 0x3
+	TypeStreamWndInc = 0x4
+	TypeStreamPri    = 0x5
+	TypeGoAway       = 0x6
+)
+
+// a flagsType is an 8-bit integer containing frame-specific flag bits in the frame header
+type flagsType uint8
+
+const (
+	flagFin            = 0x1
+	flagStreamPriority = 0x2
+	flagStreamType     = 0x4
+)
+
+func (ft flagsType) IsSet(f flagsType) bool {
+	return (ft & f) != 0
+}
+
+func (ft *flagsType) Set(f flagsType) {
+	*ft |= f
+}
+
+func (ft *flagsType) Unset(f flagsType) {
+	*ft = *ft &^ f
+}
+
+// StreamId is 31-bit integer uniquely identifying a stream within a session
+type StreamId uint32
+
+// StreamPriority is 31-bit integer specifying a stream's priority
+type StreamPriority uint32
+
+// StreamType is 32-bit integer specifying a stream's type
+type StreamType uint32
+
+// ErrorCode is a 32-bit integer indicating a error condition included in rst/goaway frames
+type ErrorCode uint32

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/wndinc.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/wndinc.go
@@ -1,0 +1,57 @@
+package frame
+
+import "io"
+
+const (
+	wndIncBodySize  = 4
+	wndIncFrameSize = headerSize + wndIncBodySize
+)
+
+// Increase a stream's flow control window size
+type RStreamWndInc struct {
+	Header
+	body [wndIncBodySize]byte
+}
+
+func (f *RStreamWndInc) WindowIncrement() (inc uint32) {
+	return order.Uint32(f.body[:]) & wndIncMask
+}
+
+func (f *RStreamWndInc) readFrom(d deserializer) (err error) {
+	if f.Length() != wndIncBodySize {
+		return protoError("WND_INC length must be %d, got %d", wndIncBodySize, f.Length())
+	}
+
+	_, err = io.ReadFull(d, f.body[:])
+	return
+}
+
+type WStreamWndInc struct {
+	Header
+	data [wndIncFrameSize]byte
+}
+
+func (f *WStreamWndInc) writeTo(s serializer) (err error) {
+	_, err = s.Write(f.data[:])
+	return
+}
+
+func (f *WStreamWndInc) Set(streamId StreamId, inc uint32) (err error) {
+	if inc > wndIncMask {
+		return protoError("Window increment %d out of range", inc)
+	}
+
+	order.PutUint32(f.data[headerSize:], inc)
+
+	if err = f.Header.SetAll(TypeStreamWndInc, wndIncBodySize, streamId, 0); err != nil {
+		return
+	}
+
+	return
+}
+
+func NewWStreamWndInc() (f *WStreamWndInc) {
+	f = new(WStreamWndInc)
+	f.Header = Header(f.data[:headerSize])
+	return
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/wndinc_test.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame/wndinc_test.go
@@ -1,0 +1,101 @@
+package frame
+
+import (
+	"reflect"
+	"testing"
+)
+
+type WndIncTestParams struct {
+	streamId StreamId
+	inc      uint32
+}
+
+func TestSerializeWndInc(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		params   WndIncTestParams
+		expected []byte
+	}{
+		{
+			WndIncTestParams{0x04b1bd09, 0x0},
+			[]byte{0x0, 0x4, 0x0, TypeStreamWndInc, 0x04, 0xb1, 0xbd, 0x09, 0x0, 0x0, 0x0, 0x0},
+		},
+		{
+			WndIncTestParams{0x0, 0x12c498},
+			[]byte{0x0, 0x4, 0x0, TypeStreamWndInc, 0x0, 0x0, 0x0, 0x0, 0x0, 0x12, 0xc4, 0x98},
+		},
+		{
+			WndIncTestParams{streamMask, wndIncMask},
+			[]byte{0x00, 0x4, 0x0, TypeStreamWndInc, 0x7F, 0xFF, 0xFF, 0xFF, 0x7F, 0xFF, 0xFF, 0xFF},
+		},
+	}
+
+	for _, tcase := range cases {
+		buf, trans := loadedTrans([]byte{})
+		var f *WStreamWndInc = NewWStreamWndInc()
+
+		if err := f.Set(tcase.params.streamId, tcase.params.inc); err != nil {
+			t.Fatalf("Error while setting params %v!", tcase.params)
+		}
+
+		if err := f.writeTo(trans); err != nil {
+			t.Fatalf("Error while writing %v!", tcase.params)
+		}
+
+		if !reflect.DeepEqual(tcase.expected, buf.Bytes()) {
+			t.Errorf("Failed to serialize STREAM_WNDINC, expected: %v got %v", tcase.expected, buf.Bytes())
+		}
+	}
+}
+
+func TestDeserializeWndInc(t *testing.T) {
+	t.Parallel()
+
+	_, trans := loadedTrans([]byte{0x00, wndIncBodySize, 0x0, TypeStreamWndInc, 0x7F, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0xc9, 0xF1})
+	h := newHeader()
+	if err := h.readFrom(trans); err != nil {
+		t.Fatalf("Failed to read header: %v", err)
+	}
+	var f RStreamWndInc
+	f.Header = h
+	if err := f.readFrom(trans); err != nil {
+		t.Fatalf("Error while reading rst frame: %v", err)
+	}
+
+	if f.WindowIncrement() != 0xc9f1 {
+		t.Errorf("Expected error code %d but got %d", 0xc9f1, f.WindowIncrement())
+	}
+}
+
+// test a bad frame length of wndIncBodySize+1
+func TestBadLengthWndInc(t *testing.T) {
+	t.Parallel()
+
+	_, trans := loadedTrans([]byte{0x00, wndIncBodySize + 1, 0x0, TypeStreamWndInc, 0x7F, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x0})
+	h := newHeader()
+	if err := h.readFrom(trans); err != nil {
+		t.Fatalf("Failed to read header: %v", err)
+	}
+	var f RStreamWndInc
+	f.Header = h
+	if err := f.readFrom(trans); err == nil {
+		t.Errorf("Expected error when setting bad wndinc frame length, got none.")
+	}
+}
+
+// test fewer than rstBodySize bytes available after header
+func TestShortReadWndInc(t *testing.T) {
+	t.Parallel()
+
+	_, trans := loadedTrans([]byte{0x00, wndIncBodySize, 0x0, TypeStreamWndInc, 0x7F, 0xFF, 0xFF, 0xFF, 0x1})
+	h := newHeader()
+	if err := h.readFrom(trans); err != nil {
+		t.Fatalf("Failed to read header: %v", err)
+	}
+	var f RStreamWndInc
+	f.Header = h
+	if err := f.readFrom(trans); err == nil {
+		t.Errorf("Expected error when reading incomplete frame, got none.")
+	}
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/interface.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/interface.go
@@ -1,0 +1,36 @@
+package proto
+
+import (
+	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame"
+	"net"
+	"time"
+)
+
+type IStream interface {
+	Write([]byte) (int, error)
+	Read([]byte) (int, error)
+	Close() error
+	SetDeadline(time.Time) error
+	SetReadDeadline(time.Time) error
+	SetWriteDeadline(time.Time) error
+	HalfClose([]byte) (int, error)
+	Id() frame.StreamId
+	StreamType() frame.StreamType
+	Session() ISession
+	RemoteAddr() net.Addr
+	LocalAddr() net.Addr
+}
+
+type ISession interface {
+	Open() (IStream, error)
+	OpenStream(frame.StreamPriority, frame.StreamType, bool) (IStream, error)
+	Accept() (IStream, error)
+	Kill() error
+	GoAway(frame.ErrorCode, []byte) error
+	LocalAddr() net.Addr
+	RemoteAddr() net.Addr
+	Close() error
+	Wait() (frame.ErrorCode, error, []byte)
+	NetListener() net.Listener
+	NetDial(_, _ string) (net.Conn, error)
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/session.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/session.go
@@ -1,0 +1,474 @@
+package proto
+
+import (
+	"fmt"
+	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame"
+	"io"
+	"net"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	defaultWindowSize       = 0x10000 // 64KB
+	defaultAcceptQueueDepth = 100
+	MinExtensionType        = 0xFFFFFFFF - 0x100 // 512 extensions
+)
+
+// private interface for Sessions to call Streams
+type stream interface {
+	IStream
+	handleStreamData(*frame.RStreamData)
+	handleStreamWndInc(*frame.RStreamWndInc)
+	handleStreamRst(*frame.RStreamRst)
+	closeWith(error)
+}
+
+// for extensions
+type ExtAccept func() (IStream, error)
+type Extension interface {
+	Start(ISession, ExtAccept) frame.StreamType
+}
+
+type deadReason struct {
+	errorCode   frame.ErrorCode
+	err         error
+	remoteDebug []byte
+}
+
+// factory function that creates new streams
+type streamFactory func(id frame.StreamId, priority frame.StreamPriority, streamType frame.StreamType, finLocal bool, finRemote bool, windowSize uint32, sess session) stream
+
+// checks the parity of a stream id (local vs remote, client vs server)
+type parityFn func(frame.StreamId) bool
+
+// state for each half of the session (remote and local)
+type halfState struct {
+	goneAway int32  // true if that half of the stream has gone away
+	lastId   uint32 // last id used/seen from one half of the session
+}
+
+// Session implements a simple streaming session manager. It has the following characteristics:
+//
+// - When closing the Session, it does not linger, all pending write operations will fail immediately.
+// - It completely ignores stream priority when processing and writing frames
+// - It offers no customization of settings like window size/ping time
+type Session struct {
+	conn              net.Conn                         // connection the transport is running over
+	transport         frame.Transport                  // transport
+	streams           StreamMap                        // all active streams
+	local             halfState                        // client state
+	remote            halfState                        // server state
+	syn               *frame.WStreamSyn                // STREAM_SYN frame for opens
+	wr                sync.Mutex                       // synchronization when writing frames
+	accept            chan stream                      // new streams opened by the remote
+	diebit            int32                            // true if we're dying
+	remoteDebug       []byte                           // debugging data sent in the remote's GoAway frame
+	defaultWindowSize uint32                           // window size when creating new streams
+	newStream         streamFactory                    // factory function to make new streams
+	dead              chan deadReason                  // dead
+	isLocal           parityFn                         // determines if a stream id is local or remote
+	exts              map[frame.StreamType]chan stream // map of extension stream type -> accept channel for the extension
+}
+
+func NewSession(conn net.Conn, newStream streamFactory, isClient bool, exts []Extension) ISession {
+	sess := &Session{
+		conn:              conn,
+		transport:         frame.NewBasicTransport(conn),
+		streams:           NewConcurrentStreamMap(),
+		local:             halfState{lastId: 0},
+		remote:            halfState{lastId: 0},
+		syn:               frame.NewWStreamSyn(),
+		diebit:            0,
+		defaultWindowSize: defaultWindowSize,
+		accept:            make(chan stream, defaultAcceptQueueDepth),
+		newStream:         newStream,
+		dead:              make(chan deadReason, 1), // don't block die() if there is no Wait call
+		exts:              make(map[frame.StreamType]chan stream),
+	}
+
+	if isClient {
+		sess.isLocal = sess.isClient
+		sess.local.lastId += 1
+	} else {
+		sess.isLocal = sess.isServer
+		sess.remote.lastId += 1
+	}
+
+	for _, ext := range exts {
+		sess.startExtension(ext)
+	}
+
+	go sess.reader()
+
+	return sess
+}
+
+////////////////////////////////
+// public interface
+////////////////////////////////
+
+func (s *Session) Open() (IStream, error) {
+	return s.OpenStream(0, 0, false)
+}
+
+func (s *Session) OpenStream(priority frame.StreamPriority, streamType frame.StreamType, fin bool) (ret IStream, err error) {
+	// check if the remote has gone away
+	if atomic.LoadInt32(&s.remote.goneAway) == 1 {
+		return nil, fmt.Errorf("Failed to create stream, remote has gone away.")
+	}
+
+	// this lock prevents the following race:
+	// goroutine1       goroutine2
+	// - inc stream id
+	//                  - inc stream id
+	//                  - send streamsyn
+	// - send streamsyn
+	s.wr.Lock()
+
+	// get the next id we can use
+	nextId := frame.StreamId(atomic.AddUint32(&s.local.lastId, 2))
+
+	// make the stream
+	str := s.newStream(nextId, priority, streamType, fin, false, s.defaultWindowSize, s)
+
+	// add to to the stream map
+	s.streams.Set(nextId, str)
+
+	// write the frame
+	if err = s.syn.Set(nextId, priority, streamType, fin); err != nil {
+		s.wr.Unlock()
+		s.die(frame.InternalError, err)
+		return
+	}
+
+	if err = s.transport.WriteFrame(s.syn); err != nil {
+		s.wr.Unlock()
+		s.die(frame.InternalError, err)
+		return
+	}
+
+	s.wr.Unlock()
+	return str, nil
+}
+
+func (s *Session) Accept() (str IStream, err error) {
+	var ok bool
+	if str, ok = <-s.accept; !ok {
+		return nil, fmt.Errorf("Session closed")
+	}
+
+	return
+}
+
+func (s *Session) Kill() error {
+	return s.transport.Close()
+}
+
+func (s *Session) Close() error {
+	return s.die(frame.NoError, fmt.Errorf("Session Close()"))
+}
+
+func (s *Session) GoAway(errorCode frame.ErrorCode, debug []byte) (err error) {
+	if !atomic.CompareAndSwapInt32(&s.local.goneAway, 0, 1) {
+		return fmt.Errorf("Already sent GoAway!")
+	}
+
+	s.wr.Lock()
+	f := frame.NewWGoAway()
+	remoteId := frame.StreamId(atomic.LoadUint32(&s.remote.lastId))
+	if err = f.Set(remoteId, errorCode, debug); err != nil {
+		s.wr.Unlock()
+		s.die(frame.InternalError, err)
+		return
+	}
+
+	if err = s.transport.WriteFrame(f); err != nil {
+		s.wr.Unlock()
+		s.die(frame.InternalError, err)
+		return
+	}
+
+	s.wr.Unlock()
+	return
+}
+
+func (s *Session) LocalAddr() net.Addr {
+	return s.conn.LocalAddr()
+}
+
+func (s *Session) RemoteAddr() net.Addr {
+	return s.conn.RemoteAddr()
+}
+
+func (s *Session) Wait() (frame.ErrorCode, error, []byte) {
+	reason := <-s.dead
+	return reason.errorCode, reason.err, reason.remoteDebug
+}
+
+////////////////////////////////
+// private interface for streams
+////////////////////////////////
+
+// removeStream removes a stream from this session's stream registry
+//
+// It does not error if the stream is not present
+func (s *Session) removeStream(id frame.StreamId) {
+	s.streams.Delete(id)
+	return
+}
+
+// writeFrame writes the given frame to the transport and returns the error from the write operation
+func (s *Session) writeFrame(f frame.WFrame, dl time.Time) (err error) {
+	s.wr.Lock()
+	s.conn.SetWriteDeadline(dl)
+	err = s.transport.WriteFrame(f)
+	s.wr.Unlock()
+	return
+}
+
+// die closes the session cleanly with the given error and protocol error code
+func (s *Session) die(errorCode frame.ErrorCode, err error) error {
+	// only one shutdown ever happens
+	if !atomic.CompareAndSwapInt32(&s.diebit, 0, 1) {
+		return fmt.Errorf("Shutdown already in progress")
+	}
+
+	// send a go away frame
+	s.GoAway(errorCode, []byte(err.Error()))
+
+	// now we're safe to stop accepting incoming connections
+	close(s.accept)
+
+	// we cleaned up as best as possible, close the transport
+	s.transport.Close()
+
+	// notify all of the streams that we're closing
+	s.streams.Each(func(id frame.StreamId, str stream) {
+		str.closeWith(fmt.Errorf("Session closed"))
+	})
+
+	s.dead <- deadReason{errorCode, err, s.remoteDebug}
+
+	return nil
+}
+
+////////////////////////////////
+// internal methods
+////////////////////////////////
+
+// reader() reads frames from the underlying transport and handles passes them to handleFrame
+func (s *Session) reader() {
+	defer s.recoverPanic("reader()")
+
+	// close all of the extension accept channels when we're done
+	// we do this here instead of in die() since otherwise it wouldn't
+	// be safe to access s.exts
+	defer func() {
+		for _, extAccept := range s.exts {
+			close(extAccept)
+		}
+	}()
+
+	for {
+		f, err := s.transport.ReadFrame()
+		if err != nil {
+			// if we fail to read a frame, terminate the session
+			_, ok := err.(*frame.FramingError)
+			if ok {
+				s.die(frame.ProtocolError, err)
+			} else {
+				s.die(frame.InternalError, err)
+			}
+			return
+		}
+
+		s.handleFrame(f)
+	}
+}
+
+func (s *Session) handleFrame(rf frame.RFrame) {
+	switch f := rf.(type) {
+	case *frame.RStreamSyn:
+		// if we're going away, refuse new streams
+		if atomic.LoadInt32(&s.local.goneAway) == 1 {
+			rstF := frame.NewWStreamRst()
+			rstF.Set(f.StreamId(), frame.RefusedStream)
+			go s.writeFrame(rstF, time.Time{})
+			return
+		}
+
+		if f.StreamId() <= frame.StreamId(atomic.LoadUint32(&s.remote.lastId)) {
+			s.die(frame.ProtocolError, fmt.Errorf("Stream id %d is less than last remote id.", f.StreamId()))
+			return
+		}
+
+		if s.isLocal(f.StreamId()) {
+			s.die(frame.ProtocolError, fmt.Errorf("Stream id has wrong parity for remote endpoint: %d", f.StreamId()))
+			return
+		}
+
+		// update last remote id
+		atomic.StoreUint32(&s.remote.lastId, uint32(f.StreamId()))
+
+		// make the new stream
+		str := s.newStream(f.StreamId(), f.StreamPriority(), f.StreamType(), false, f.Fin(), s.defaultWindowSize, s)
+
+		// add it to the stream map
+		s.streams.Set(f.StreamId(), str)
+
+		// check if this is an extension stream
+		if f.StreamType() >= MinExtensionType {
+			extAccept, ok := s.exts[f.StreamType()]
+			if !ok {
+				// Extension type of stream not registered
+				fRst := frame.NewWStreamRst()
+				if err := fRst.Set(f.StreamId(), frame.StreamClosed); err != nil {
+					s.die(frame.InternalError, err)
+				}
+
+				s.wr.Lock()
+				defer s.wr.Unlock()
+				s.transport.WriteFrame(fRst)
+			} else {
+				extAccept <- str
+			}
+
+			return
+		}
+
+		// put the new stream on the accept channel
+		s.accept <- str
+
+	case *frame.RStreamData:
+		if str := s.getStream(f.StreamId()); str != nil {
+			str.handleStreamData(f)
+		} else {
+			// if we get a data frame on a non-existent connection, we still
+			// need to read out the frame body so that the stream stays in a
+			// good state. read the payload into a throwaway buffer
+			discard := make([]byte, f.Length())
+			io.ReadFull(f.Reader(), discard)
+
+			// DATA frames on closed connections are just stream-level errors
+			fRst := frame.NewWStreamRst()
+			if err := fRst.Set(f.StreamId(), frame.StreamClosed); err != nil {
+				s.die(frame.InternalError, err)
+			}
+
+			s.wr.Lock()
+			defer s.wr.Unlock()
+			s.transport.WriteFrame(fRst)
+			return
+		}
+
+	case *frame.RStreamRst:
+		// delegate to the stream to handle these frames
+		if str := s.getStream(f.StreamId()); str != nil {
+			str.handleStreamRst(f)
+		}
+	case *frame.RStreamWndInc:
+		// delegate to the stream to handle these frames
+		if str := s.getStream(f.StreamId()); str != nil {
+			str.handleStreamWndInc(f)
+		}
+
+	case *frame.RGoAway:
+		atomic.StoreInt32(&s.remote.goneAway, 1)
+		s.remoteDebug = f.Debug()
+
+		lastId := f.LastStreamId()
+		s.streams.Each(func(id frame.StreamId, str stream) {
+			// close all streams that we opened above the last handled id
+			if s.isLocal(str.Id()) && str.Id() > lastId {
+				str.closeWith(fmt.Errorf("Remote is going away"))
+			}
+		})
+
+	default:
+		s.die(frame.ProtocolError, fmt.Errorf("Unrecognized frame type: %v", reflect.TypeOf(f)))
+		return
+	}
+}
+
+func (s *Session) recoverPanic(prefix string) {
+	if r := recover(); r != nil {
+		s.die(frame.InternalError, fmt.Errorf("%s panic: %v", prefix, r))
+	}
+}
+
+func (s *Session) getStream(id frame.StreamId) (str stream) {
+	// decide if this id is in the "idle" state (i.e. greater than any we've seen for that parity)
+	var lastId *uint32
+	if s.isLocal(id) {
+		lastId = &s.local.lastId
+	} else {
+		lastId = &s.remote.lastId
+	}
+
+	if uint32(id) > atomic.LoadUint32(lastId) {
+		s.die(frame.ProtocolError, fmt.Errorf("%d is an invalid, unassigned stream id", id))
+	}
+
+	// find the stream in the stream map
+	var ok bool
+	if str, ok = s.streams.Get(id); !ok {
+		return nil
+	}
+
+	return
+}
+
+// check if a stream id is for a client stream. client streams are odd
+func (s *Session) isClient(id frame.StreamId) bool {
+	return uint32(id)&1 == 1
+}
+
+func (s *Session) isServer(id frame.StreamId) bool {
+	return !s.isClient(id)
+}
+
+//////////////////////////////////////////////
+// session extensions
+//////////////////////////////////////////////
+func (s *Session) startExtension(ext Extension) {
+	accept := make(chan stream)
+	extAccept := func() (IStream, error) {
+		s, ok := <-accept
+		if !ok {
+			return nil, fmt.Errorf("Failed to accept connection, shutting down")
+		}
+
+		return s, nil
+	}
+
+	extType := ext.Start(s, extAccept)
+	s.exts[extType] = accept
+}
+
+//////////////////////////////////////////////
+// net adaptors
+//////////////////////////////////////////////
+func (s *Session) NetDial(_, _ string) (net.Conn, error) {
+	str, err := s.Open()
+	return net.Conn(str), err
+}
+
+func (s *Session) NetListener() net.Listener {
+	return &netListenerAdaptor{s}
+}
+
+type netListenerAdaptor struct {
+	*Session
+}
+
+func (a *netListenerAdaptor) Addr() net.Addr {
+	return a.LocalAddr()
+}
+
+func (a *netListenerAdaptor) Accept() (net.Conn, error) {
+	str, err := a.Session.Accept()
+	return net.Conn(str), err
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/session_test.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/session_test.go
@@ -1,0 +1,340 @@
+package proto
+
+import (
+	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func fakeStreamFactory(id frame.StreamId, priority frame.StreamPriority, streamType frame.StreamType, finLocal bool, finRemote bool, windowSize uint32, sess session) stream {
+	return new(fakeStream)
+}
+
+type fakeStream struct {
+}
+
+func (s *fakeStream) Write([]byte) (int, error)               { return 0, nil }
+func (s *fakeStream) Read([]byte) (int, error)                { return 0, nil }
+func (s *fakeStream) Close() error                            { return nil }
+func (s *fakeStream) SetDeadline(time.Time) error             { return nil }
+func (s *fakeStream) SetReadDeadline(time.Time) error         { return nil }
+func (s *fakeStream) SetWriteDeadline(time.Time) error        { return nil }
+func (s *fakeStream) HalfClose([]byte) (int, error)           { return 0, nil }
+func (s *fakeStream) Id() frame.StreamId                      { return 0 }
+func (s *fakeStream) StreamType() frame.StreamType            { return 0 }
+func (s *fakeStream) Session() ISession                       { return nil }
+func (s *fakeStream) RemoteAddr() net.Addr                    { return nil }
+func (s *fakeStream) LocalAddr() net.Addr                     { return nil }
+func (s *fakeStream) handleStreamData(*frame.RStreamData)     {}
+func (s *fakeStream) handleStreamWndInc(*frame.RStreamWndInc) {}
+func (s *fakeStream) handleStreamRst(*frame.RStreamRst)       {}
+func (s *fakeStream) closeWith(error)                         {}
+
+type fakeConn struct {
+	in     *io.PipeReader
+	out    *io.PipeWriter
+	closed bool
+}
+
+func (c *fakeConn) SetDeadline(time.Time) error      { return nil }
+func (c *fakeConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *fakeConn) SetWriteDeadline(time.Time) error { return nil }
+func (c *fakeConn) LocalAddr() net.Addr              { return nil }
+func (c *fakeConn) RemoteAddr() net.Addr             { return nil }
+func (c *fakeConn) Close() error                     { c.closed = true; c.in.Close(); return c.out.Close() }
+func (c *fakeConn) Read(p []byte) (int, error)       { return c.in.Read(p) }
+func (c *fakeConn) Write(p []byte) (int, error)      { return c.out.Write(p) }
+func (c *fakeConn) Discard()                         { go io.Copy(ioutil.Discard, c.in) }
+
+func newFakeConnPair() (local *fakeConn, remote *fakeConn) {
+	local, remote = new(fakeConn), new(fakeConn)
+	local.in, remote.out = io.Pipe()
+	remote.in, local.out = io.Pipe()
+	return
+}
+
+func TestFailWrongClientParity(t *testing.T) {
+	t.Parallel()
+
+	local, remote := newFakeConnPair()
+
+	// don't need the remote output
+	remote.Discard()
+
+	// false for a server session
+	s := NewSession(local, fakeStreamFactory, false, []Extension{})
+
+	// 300 is even, and only servers send even stream ids
+	f := frame.NewWStreamSyn()
+	f.Set(300, 0, 0, false)
+
+	// send the frame into the session
+	trans := frame.NewBasicTransport(remote)
+	trans.WriteFrame(f)
+
+	// wait for failure
+	code, err, _ := s.Wait()
+
+	if code != frame.ProtocolError {
+		t.Errorf("Session not terminated with protocol error. Got %d, expected %d. Session error: %v", code, frame.ProtocolError, err)
+	}
+
+	if !local.closed {
+		t.Errorf("Session transport not closed after protocol failure.")
+	}
+}
+
+func TestWrongServerParity(t *testing.T) {
+	t.Parallel()
+
+	local, remote := newFakeConnPair()
+
+	// true for a client session
+	s := NewSession(local, fakeStreamFactory, true, []Extension{})
+
+	// don't need the remote output
+	remote.Discard()
+
+	// 300 is even, and only servers send even stream ids
+	f := frame.NewWStreamSyn()
+	f.Set(301, 0, 0, false)
+
+	// send the frame into the session
+	trans := frame.NewBasicTransport(remote)
+	trans.WriteFrame(f)
+
+	// wait for failure
+	code, err, _ := s.Wait()
+
+	if code != frame.ProtocolError {
+		t.Errorf("Session not terminated with protocol error. Got %d, expected %d. Session error: %v", code, frame.ProtocolError, err)
+	}
+
+	if !local.closed {
+		t.Errorf("Session transport not closed after protocol failure.")
+	}
+}
+
+func TestAcceptStream(t *testing.T) {
+	t.Parallel()
+
+	local, remote := newFakeConnPair()
+
+	// don't need the remote output
+	remote.Discard()
+
+	// true for a client session
+	s := NewSession(local, NewStream, true, []Extension{})
+	defer s.Close()
+
+	f := frame.NewWStreamSyn()
+	f.Set(300, 0, 0, false)
+
+	// send the frame into the session
+	trans := frame.NewBasicTransport(remote)
+	trans.WriteFrame(f)
+
+	done := make(chan int)
+	go func() {
+		defer func() { done <- 1 }()
+
+		// wait for accept
+		str, err := s.Accept()
+
+		if err != nil {
+			t.Errorf("Error accepting stream: %v", err)
+			return
+		}
+
+		if str.Id() != frame.StreamId(300) {
+			t.Errorf("Stream has wrong id. Expected %d, got %d", str.Id(), 300)
+		}
+	}()
+
+	select {
+	case <-time.After(time.Second):
+		t.Fatalf("Timed out!")
+	case <-done:
+	}
+}
+
+func TestSynLowId(t *testing.T) {
+	t.Parallel()
+
+	local, remote := newFakeConnPair()
+
+	// don't need the remote output
+	remote.Discard()
+
+	// true for a client session
+	s := NewSession(local, fakeStreamFactory, true, []Extension{})
+
+	// Start a stream
+	f := frame.NewWStreamSyn()
+	f.Set(302, 0, 0, false)
+
+	// send the frame into the session
+	trans := frame.NewBasicTransport(remote)
+	trans.WriteFrame(f)
+
+	// accept it
+	s.Accept()
+
+	// Start a closed stream at a lower id number
+	f.Set(300, 0, 0, false)
+
+	// send the frame into the session
+	trans.WriteFrame(f)
+
+	code, err, _ := s.Wait()
+	if code != frame.ProtocolError {
+		t.Errorf("Session not terminated with protocol error, got %d expected %d. Error: %v", code, frame.ProtocolError, err)
+	}
+}
+
+// Check that sending a frame of the wrong size responds with FRAME_SIZE_ERROR
+func TestFrameSizeError(t *testing.T) {
+}
+
+// Check that we get a protocol error for sending STREAM_DATA on a stream id that was never opened
+func TestDataOnClosed(t *testing.T) {
+}
+
+// Check that we get nothing for sending STREAM_WND_INC on a stream id that was never opened
+func TestWndIncOnClosed(t *testing.T) {
+}
+
+// Check that we get nothing for sending STREAM_RST on a stream id that was never opened
+func TestRstOnClosed(t *testing.T) {
+}
+
+func TestGoAway(t *testing.T) {
+}
+
+func TestCloseGoAway(t *testing.T) {
+}
+
+func TestKill(t *testing.T) {
+}
+
+// make sure we get a valid syn frame from opening a new stream
+func TestOpen(t *testing.T) {
+}
+
+// test opening a new stream that is immediately half-closed
+func TestOpenWithFin(t *testing.T) {
+}
+
+// validate that a session fulfills the net.Listener interface
+// compile-only check
+func TestNetListener(t *testing.T) {
+	t.Parallel()
+
+	_ = func() {
+		s := NewSession(new(fakeConn), NewStream, false, []Extension{})
+		http.Serve(s.NetListener(), nil)
+	}
+}
+
+func TestNetListenerAccept(t *testing.T) {
+	t.Parallel()
+	local, remote := newFakeConnPair()
+
+	sLocal := NewSession(local, NewStream, false, []Extension{})
+	sRemote := NewSession(remote, NewStream, true, []Extension{})
+
+	go func() {
+		_, err := sRemote.Open()
+		if err != nil {
+			t.Errorf("Failed to open stream: %v", err)
+			return
+		}
+	}()
+
+	l := sLocal.NetListener()
+
+	_, err := l.Accept()
+	if err != nil {
+		t.Fatalf("Failed to accept stream: %v", err)
+	}
+}
+
+// set up a fake extension which tries to accept a stream.
+// we're testing to make sure that when the remote side closes the connection
+// that the extension actually gets an error back from its accept() method
+type fakeExt struct {
+	closeOk chan int
+}
+
+func (e *fakeExt) Start(sess ISession, accept ExtAccept) frame.StreamType {
+	go func() {
+		_, err := accept()
+		if err != nil {
+			// we should get an error when the session close
+			e.closeOk <- 1
+		}
+	}()
+
+	return MinExtensionType
+}
+
+func TestExtensionCleanupAccept(t *testing.T) {
+	t.Parallel()
+	local, remote := newFakeConnPair()
+
+	closeOk := make(chan int)
+	_ = NewSession(local, NewStream, false, []Extension{&fakeExt{closeOk}})
+	sRemote := NewSession(remote, NewStream, true, []Extension{})
+
+	sRemote.Close()
+
+	select {
+	case <-time.After(time.Second):
+		t.Fatalf("Timed out!")
+	case <-closeOk:
+	}
+}
+
+func TestWriteAfterClose(t *testing.T) {
+	t.Parallel()
+	local, remote := newFakeConnPair()
+	sLocal := NewSession(local, NewStream, false, []Extension{})
+	sRemote := NewSession(remote, NewStream, true, []Extension{})
+
+	closed := make(chan int)
+	go func() {
+		stream, err := sRemote.Open()
+		if err != nil {
+			t.Errorf("Failed to open stream: %v", err)
+			return
+		}
+
+		<-closed
+		if _, err = stream.Write([]byte("test!")); err != nil {
+			t.Errorf("Failed to write test data: %v", err)
+			return
+		}
+
+		if _, err := sRemote.Open(); err != nil {
+			t.Errorf("Failed to open second stream: %v", err)
+			return
+		}
+	}()
+
+	stream, err := sLocal.Accept()
+	if err != nil {
+		t.Fatalf("Failed to accept stream!")
+	}
+
+	// tell the other side that we closed so they can write late
+	stream.Close()
+	closed <- 1
+
+	if _, err = sLocal.Accept(); err != nil {
+		t.Fatalf("Failed to accept second connection: %v", err)
+	}
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/stream.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/stream.go
@@ -1,0 +1,319 @@
+package proto
+
+import (
+	"fmt"
+	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/buffer"
+	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	zeroTime         time.Time
+	resetRemoveDelay = 10 * time.Second
+	closeError       = fmt.Errorf("Stream closed")
+)
+
+type Stream struct {
+	id            frame.StreamId       // stream id (const)
+	streamType    frame.StreamType     // related stream id (const)
+	session       session              // the parent session (const)
+	inBuffer      *buffer.Inbound      // buffer for data coming in from the remote side
+	outBuffer     *buffer.Outbound     // manages size of the outbound window
+	sentRst       uint32               // == 1 only if we sent a reset to close this connection
+	writer        sync.Mutex           // only one writer at a time
+	wdata         *frame.WStreamData   // the frame this stream is currently writing
+	winc          *frame.WStreamWndInc // window increment currently being written
+	readDeadline  time.Time            // deadline for reads (protected by buffer mutex)
+	writeDeadline time.Time            // deadline for writes (protected by writer mutex)
+}
+
+// private interface for Streams to call Sessions
+type session interface {
+	ISession
+	writeFrame(frame.WFrame, time.Time) error
+	die(frame.ErrorCode, error) error
+	removeStream(frame.StreamId)
+}
+
+////////////////////////////////
+// public interface
+////////////////////////////////
+func NewStream(id frame.StreamId, priority frame.StreamPriority, streamType frame.StreamType, finLocal bool, finRemote bool, windowSize uint32, sess session) stream {
+	str := &Stream{
+		id:         id,
+		inBuffer:   buffer.NewInbound(int(windowSize)),
+		outBuffer:  buffer.NewOutbound(int(windowSize)),
+		streamType: streamType,
+		session:    sess,
+		wdata:      frame.NewWStreamData(),
+		winc:       frame.NewWStreamWndInc(),
+	}
+
+	if finLocal {
+		str.inBuffer.SetError(io.EOF)
+	}
+
+	if finRemote {
+		str.outBuffer.SetError(fmt.Errorf("Stream closed"))
+	}
+
+	return str
+}
+
+func (s *Stream) Write(buf []byte) (n int, err error) {
+	return s.write(buf, false)
+}
+
+func (s *Stream) Read(buf []byte) (n int, err error) {
+	// read from the buffer
+	n, err = s.inBuffer.Read(buf)
+
+	// if we read more than zero, we send a window update
+	if n > 0 {
+		errWnd := s.sendWindowUpdate(uint32(n))
+		if errWnd != nil {
+			err = errWnd
+			s.die(frame.InternalError, err)
+		}
+	}
+
+	return
+}
+
+// Close closes the stream in a manner that attempts to emulate a net.Conn's Close():
+// - It calls HalfClose() with an empty buffer to half-close the stream on the remote side
+// - It calls closeWith() so that all future Read/Write operations will fail
+// - If the stream receives another STREAM_DATA frame from the remote side, it will send a STREAM_RST with a CANCELED error code
+func (s *Stream) Close() error {
+	s.HalfClose([]byte{})
+	s.closeWith(closeError)
+	return nil
+}
+
+func (s *Stream) SetDeadline(deadline time.Time) (err error) {
+	if err = s.SetReadDeadline(deadline); err != nil {
+		return
+	}
+	if err = s.SetWriteDeadline(deadline); err != nil {
+		return
+	}
+	return
+}
+
+func (s *Stream) SetReadDeadline(dl time.Time) error {
+	s.inBuffer.SetDeadline(dl)
+	return nil
+}
+
+func (s *Stream) SetWriteDeadline(dl time.Time) error {
+	s.writer.Lock()
+	s.writeDeadline = dl
+	s.writer.Unlock()
+	return nil
+}
+
+func (s *Stream) HalfClose(buf []byte) (n int, err error) {
+	return s.write(buf, true)
+}
+
+func (s *Stream) Id() frame.StreamId {
+	return s.id
+}
+
+func (s *Stream) StreamType() frame.StreamType {
+	return s.streamType
+}
+
+func (s *Stream) Session() ISession {
+	return s.session
+}
+
+func (s *Stream) LocalAddr() net.Addr {
+	return s.session.LocalAddr()
+}
+
+func (s *Stream) RemoteAddr() net.Addr {
+	return s.session.RemoteAddr()
+}
+
+/////////////////////////////////////
+// session's stream interface
+/////////////////////////////////////
+func (s *Stream) handleStreamData(f *frame.RStreamData) {
+	// skip writing for zero-length frames (typically for sending FIN)
+	if f.Length() > 0 {
+		// write the data into the buffer
+		if _, err := s.inBuffer.ReadFrom(f.Reader()); err != nil {
+			if err == buffer.FullError {
+				s.resetWith(frame.FlowControlError, fmt.Errorf("Flow control buffer overflowed"))
+			} else if err == closeError {
+				// We're trying to emulate net.Conn's Close() behavior where we close our side of the connection,
+				// and if we get any more frames from the other side, we RST it.
+				s.resetWith(frame.Cancel, fmt.Errorf("Stream closed"))
+			} else if err == buffer.AlreadyClosed {
+				// there was already an error set
+				s.resetWith(frame.StreamClosed, err)
+			} else {
+				// the transport returned some sort of IO error
+				s.die(frame.ProtocolError, err)
+			}
+			return
+		}
+	}
+
+	if f.Fin() {
+		s.inBuffer.SetError(io.EOF)
+		s.maybeRemove()
+	}
+
+}
+
+func (s *Stream) handleStreamRst(f *frame.RStreamRst) {
+	s.closeWith(fmt.Errorf("Stream reset by peer with error %d", f.ErrorCode()))
+}
+
+func (s *Stream) handleStreamWndInc(f *frame.RStreamWndInc) {
+	s.outBuffer.Increment(int(f.WindowIncrement()))
+}
+
+func (s *Stream) closeWith(err error) {
+	s.outBuffer.SetError(err)
+	s.inBuffer.SetError(err)
+	s.session.removeStream(s.id)
+}
+
+////////////////////////////////
+// internal methods
+////////////////////////////////
+
+func (s *Stream) closeWithAndRemoveLater(err error) {
+	s.outBuffer.SetError(err)
+	s.inBuffer.SetError(err)
+	time.AfterFunc(resetRemoveDelay, func() {
+		s.session.removeStream(s.id)
+	})
+}
+
+func (s *Stream) maybeRemove() {
+	if buffer.BothClosed(s.inBuffer, s.outBuffer) {
+		s.session.removeStream(s.id)
+	}
+}
+
+func (s *Stream) resetWith(errorCode frame.ErrorCode, resetErr error) {
+	// only ever send one reset
+	if !atomic.CompareAndSwapUint32(&s.sentRst, 0, 1) {
+		return
+	}
+
+	// close the stream
+	s.closeWithAndRemoveLater(resetErr)
+
+	// make the reset frame
+	rst := frame.NewWStreamRst()
+	if err := rst.Set(s.id, errorCode); err != nil {
+		s.die(frame.InternalError, err)
+	}
+
+	// need write lock to make sure no data frames get sent after we send the reset
+	s.writer.Lock()
+
+	// send it
+	if err := s.session.writeFrame(rst, zeroTime); err != nil {
+		s.writer.Unlock()
+		s.die(frame.InternalError, err)
+	}
+
+	s.writer.Unlock()
+}
+
+func (s *Stream) write(buf []byte, fin bool) (n int, err error) {
+	// a write call can pass a buffer larger that we can send in a single frame
+	// only allow one writer at a time to prevent interleaving frames from concurrent writes
+	s.writer.Lock()
+
+	bufSize := len(buf)
+	bytesRemaining := bufSize
+	for bytesRemaining > 0 || fin {
+		// figure out the most we can write in a single frame
+		writeReqSize := min(0x3FFF, bytesRemaining)
+
+		// and then reduce that to however much is available in the window
+		// this blocks until window is available and may not return all that we asked for
+		var writeSize int
+		if writeSize, err = s.outBuffer.Decrement(writeReqSize); err != nil {
+			s.writer.Unlock()
+			return
+		}
+
+		// calculate the slice of the buffer we'll write
+		start, end := n, n+writeSize
+
+		// only send fin for the last frame
+		finBit := fin && end == bufSize
+
+		// make the frame
+		if err = s.wdata.Set(s.id, buf[start:end], finBit); err != nil {
+			s.writer.Unlock()
+			s.die(frame.InternalError, err)
+			return
+		}
+
+		// write the frame
+		if err = s.session.writeFrame(s.wdata, s.writeDeadline); err != nil {
+			s.writer.Unlock()
+			return
+		}
+
+		// update our counts
+		n += writeSize
+		bytesRemaining -= writeSize
+
+		if finBit {
+			s.outBuffer.SetError(fmt.Errorf("Stream closed"))
+			s.maybeRemove()
+
+			// handles the empty buffer case with fin case
+			fin = false
+		}
+	}
+
+	s.writer.Unlock()
+	return
+}
+
+// sendWindowUpdate sends a window increment frame
+// with the given increment
+func (s *Stream) sendWindowUpdate(inc uint32) (err error) {
+	// send a window update
+	if err = s.winc.Set(s.id, inc); err != nil {
+		return
+	}
+
+	// XXX: write this async? We can only write one at
+	// a time if we're not allocating new ones from the heap
+	if err = s.session.writeFrame(s.winc, zeroTime); err != nil {
+		return
+	}
+
+	return
+}
+
+// die is called when a protocol error occurs and the entire
+// session must be destroyed.
+func (s *Stream) die(errorCode frame.ErrorCode, err error) {
+	s.closeWith(fmt.Errorf("Stream closed on error: %v", err))
+	s.session.die(errorCode, err)
+}
+
+func min(n1, n2 int) int {
+	if n1 > n2 {
+		return n2
+	} else {
+		return n1
+	}
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/stream_map.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/stream_map.go
@@ -1,0 +1,59 @@
+package proto
+
+import (
+	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame"
+	"sync"
+)
+
+const (
+	initMapCapacity = 128 // not too much extra memory wasted to avoid allocations
+)
+
+type StreamMap interface {
+	Get(frame.StreamId) (stream, bool)
+	Set(frame.StreamId, stream)
+	Delete(frame.StreamId)
+	Each(func(frame.StreamId, stream))
+}
+
+// ConcurrentStreamMap is a map of stream ids -> streams guarded by a read/write lock
+type ConcurrentStreamMap struct {
+	sync.RWMutex
+	table map[frame.StreamId]stream
+}
+
+func (m *ConcurrentStreamMap) Get(id frame.StreamId) (s stream, ok bool) {
+	m.RLock()
+	s, ok = m.table[id]
+	m.RUnlock()
+	return
+}
+
+func (m *ConcurrentStreamMap) Set(id frame.StreamId, str stream) {
+	m.Lock()
+	m.table[id] = str
+	m.Unlock()
+}
+
+func (m *ConcurrentStreamMap) Delete(id frame.StreamId) {
+	m.Lock()
+	delete(m.table, id)
+	m.Unlock()
+}
+
+func (m *ConcurrentStreamMap) Each(fn func(frame.StreamId, stream)) {
+	m.Lock()
+	streams := make(map[frame.StreamId]stream, len(m.table))
+	for k, v := range m.table {
+		streams[k] = v
+	}
+	m.Unlock()
+
+	for id, str := range streams {
+		fn(id, str)
+	}
+}
+
+func NewConcurrentStreamMap() *ConcurrentStreamMap {
+	return &ConcurrentStreamMap{table: make(map[frame.StreamId]stream, initMapCapacity)}
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/stream_test.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/stream_test.go
@@ -1,0 +1,283 @@
+package proto
+
+import (
+	"fmt"
+	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/frame"
+	"io"
+	"io/ioutil"
+	"testing"
+	"time"
+)
+
+func TestSendHalfCloseWithZeroWindow(t *testing.T) {
+	t.Parallel()
+
+	local, remote := newFakeConnPair()
+
+	s := NewSession(local, NewStream, false, []Extension{})
+	s.(*Session).defaultWindowSize = 10
+
+	go func() {
+		trans := frame.NewBasicTransport(remote)
+		f, err := trans.ReadFrame()
+		if err != nil {
+			t.Errorf("Failed to read next frame: %v", err)
+			return
+		}
+
+		_, ok := f.(*frame.RStreamSyn)
+		if !ok {
+			t.Errorf("Wrong frame type. Got %v, expected %v", f.Type(), frame.TypeStreamSyn)
+			return
+		}
+
+		f, err = trans.ReadFrame()
+		if err != nil {
+			t.Errorf("Failed to read next frame: %v", err)
+			return
+		}
+
+		fr, ok := f.(*frame.RStreamData)
+		if !ok {
+			t.Errorf("Wrong frame type. Got %v, expected %v", f.Type(), frame.TypeStreamData)
+			return
+		}
+
+		if fr.Length() != 10 {
+			t.Errorf("Wrong data length. Got %v, expected %d", fr.Length(), 10)
+			return
+		}
+
+		n, err := io.CopyN(ioutil.Discard, fr.Reader(), 10)
+		if n != 10 {
+			t.Errorf("Wrong read size. Got %d, expected %d", n, 10)
+			return
+		}
+
+		f, err = trans.ReadFrame()
+		if err != nil {
+			t.Errorf("Failed to read next frame: %v", err)
+			return
+		}
+
+		fr, ok = f.(*frame.RStreamData)
+		if !ok {
+			t.Errorf("Wrong frame type. Got %v, expected %v", f.Type(), frame.TypeStreamData)
+			return
+		}
+
+		if !fr.Fin() {
+			t.Errorf("Wrong frame flags. Expected fin flag to be set.")
+			return
+		}
+
+		trans.ReadFrame()
+	}()
+
+	str, err := s.Open()
+	if err != nil {
+		t.Fatalf("Failed to open stream: %v", err)
+	}
+
+	_, err = str.Write(make([]byte, 10))
+	if err != nil {
+		t.Fatalf("Failed to write data: %v", err)
+	}
+
+	_, err = str.HalfClose([]byte{})
+	if err != nil {
+		t.Fatalf("Failed to half-close with an empty buffer")
+	}
+}
+
+func TestDataAfterRst(t *testing.T) {
+	local, remote := newFakeConnPair()
+
+	_ = NewSession(local, NewStream, false, []Extension{})
+	trans := frame.NewBasicTransport(remote)
+
+	// make sure that we get an RST STREAM_CLOSED
+	done := make(chan int)
+	go func() {
+		defer func() { done <- 1 }()
+
+		f, err := trans.ReadFrame()
+		if err != nil {
+			t.Errorf("Failed to read frame sent from session: %v", err)
+			return
+		}
+
+		fr, ok := f.(*frame.RStreamRst)
+		if !ok {
+			t.Errorf("Frame is not STREAM_RST: %v", f)
+			return
+		}
+
+		if fr.ErrorCode() != frame.StreamClosed {
+			t.Errorf("Error code on STREAM_RST is not STREAM_CLOSED. Got %d, expected %d", fr.ErrorCode(), frame.StreamClosed)
+			return
+		}
+	}()
+
+	fSyn := frame.NewWStreamSyn()
+	if err := fSyn.Set(301, 0, 0, false); err != nil {
+		t.Fatalf("Failed to make syn frame: %v", err)
+	}
+
+	if err := trans.WriteFrame(fSyn); err != nil {
+		t.Fatalf("Failed to send syn: %v", err)
+	}
+
+	fRst := frame.NewWStreamRst()
+	if err := fRst.Set(301, frame.Cancel); err != nil {
+		t.Fatal("Failed to make rst frame: %v", err)
+	}
+
+	if err := trans.WriteFrame(fRst); err != nil {
+		t.Fatalf("Failed to write rst frame: %v", err)
+	}
+
+	fData := frame.NewWStreamData()
+	if err := fData.Set(301, []byte{0xa, 0xFF}, false); err != nil {
+		t.Fatalf("Failed to set data frame")
+	}
+
+	trans.WriteFrame(fData)
+
+	<-done
+}
+
+func TestFlowControlError(t *testing.T) {
+	local, remote := newFakeConnPair()
+
+	s := NewSession(local, NewStream, false, []Extension{})
+	s.(*Session).defaultWindowSize = 10
+	trans := frame.NewBasicTransport(remote)
+
+	// make sure that we get an RST FLOW_CONTROL_ERROR
+	done := make(chan int)
+	go func() {
+		defer func() { done <- 1 }()
+
+		f, err := trans.ReadFrame()
+		if err != nil {
+			t.Errorf("Failed to read frame sent from session: %v", err)
+			return
+		}
+
+		fr, ok := f.(*frame.RStreamRst)
+		if !ok {
+			t.Errorf("Frame is not STREAM_RST: %v", f)
+			return
+		}
+
+		if fr.ErrorCode() != frame.FlowControlError {
+			t.Errorf("Error code on STREAM_RST is not FLOW_CONTROL_ERROR. Got %d, expected %d", fr.ErrorCode(), frame.FlowControlError)
+			return
+		}
+	}()
+
+	fSyn := frame.NewWStreamSyn()
+	if err := fSyn.Set(301, 0, 0, false); err != nil {
+		t.Fatalf("Failed to make syn frame: %v", err)
+	}
+
+	if err := trans.WriteFrame(fSyn); err != nil {
+		t.Fatalf("Failed to send syn: %v", err)
+	}
+
+	fData := frame.NewWStreamData()
+	if err := fData.Set(301, make([]byte, 11), false); err != nil {
+		t.Fatalf("Failed to set data frame")
+	}
+
+	trans.WriteFrame(fData)
+
+	<-done
+}
+
+func TestTolerateLateFrameAfterRst(t *testing.T) {
+	local, remote := newFakeConnPair()
+
+	s := NewSession(local, NewStream, false, []Extension{})
+	trans := frame.NewBasicTransport(remote)
+
+	// make sure that we don't get any error on a late frame
+	done := make(chan int)
+	go func() {
+		defer func() { done <- 1 }()
+		// read syn
+		trans.ReadFrame()
+		// read rst
+		trans.ReadFrame()
+
+		// should block
+		if f, err := trans.ReadFrame(); err != nil {
+			t.Errorf("Error reading frame: %v", err)
+		} else {
+			t.Errorf("Got frame that we shouldn't have read: %v. Type: %v", f, f.Type())
+		}
+	}()
+
+	str, err := s.Open()
+	if err != nil {
+		t.Fatalf("failed to open stream")
+	}
+
+	str.(*Stream).resetWith(frame.Cancel, fmt.Errorf("cancel"))
+
+	fData := frame.NewWStreamData()
+	if err := fData.Set(str.Id(), []byte{0x1, 0x2, 0x3}, false); err != nil {
+		t.Fatalf("Failed to set data frame")
+	}
+	trans.WriteFrame(fData)
+
+	select {
+	case <-done:
+		t.Fatalf("Stream sent response to late DATA frame")
+
+	case <-time.After(1 * time.Second):
+		// ok
+	}
+}
+
+// Test that we remove a stream from the session if both sides half-close
+func TestRemoveAfterHalfClose(t *testing.T) {
+	local, remote := newFakeConnPair()
+	remote.Discard()
+
+	s := NewSession(local, NewStream, false, []Extension{})
+	trans := frame.NewBasicTransport(remote)
+
+	// open stream
+	str, err := s.Open()
+	if err != nil {
+		t.Fatalf("failed to open stream")
+	}
+
+	// half close remote side (true means half-close)
+	fData := frame.NewWStreamData()
+	if err := fData.Set(str.Id(), []byte{0x1, 0x2, 0x3}, true); err != nil {
+		t.Fatalf("Failed to set data frame")
+	}
+
+	if err := trans.WriteFrame(fData); err != nil {
+		t.Fatalf("Failed to write data frame")
+	}
+
+	// half-close local side
+	str.HalfClose([]byte{0xFF, 0xFE, 0xFD, 0xFC})
+
+	// yield so the stream can process
+	time.Sleep(0)
+
+	// verify stream is removed
+	if stream, ok := s.(*Session).streams.Get(str.Id()); ok {
+		t.Fatalf("Expected stream %d to be removed after both sides half-closed, but found: %v!", str.Id(), stream)
+
+	}
+}
+
+// Test that we get a RST if we send a DATA frame after we send a DATA frame with a FIN
+func TestDataAfterFin(t *testing.T) {
+}

--- a/Godeps/_workspace/src/github.com/inconshreveable/muxado/server.go
+++ b/Godeps/_workspace/src/github.com/inconshreveable/muxado/server.go
@@ -1,0 +1,71 @@
+package muxado
+
+import (
+	"crypto/tls"
+	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto"
+	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado/proto/ext"
+	"net"
+)
+
+// A Listener accepts new connections from its net.Listener
+// and begins muxado server connections on them.
+//
+// It's API is very similar to a net.Listener, but it returns
+// muxado.Sessions instead of net.Conn's.
+type Listener struct {
+	wrapped net.Listener
+}
+
+// Accept the next connection from the listener and begin
+// a muxado session on it.
+func (l *Listener) Accept() (Session, error) {
+	conn, err := l.wrapped.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	return Server(conn), nil
+}
+
+// Addr returns the bound address of the wrapped net.Listener
+func (l *Listener) Addr() net.Addr {
+	return l.wrapped.Addr()
+}
+
+// Close closes the wrapped net.Listener
+func (l *Listener) Close() error {
+	return l.wrapped.Close()
+}
+
+// Server returns a muxado server session using conn as the transport.
+func Server(conn net.Conn) Session {
+	return &sessionAdaptor{proto.NewSession(conn, proto.NewStream, false, []proto.Extension{ext.NewDefaultHeartbeat()})}
+}
+
+// Listen binds to a network address and returns a Listener which accepts
+// new connections and starts muxado server sessions on them.
+func Listen(network, addr string) (*Listener, error) {
+	l, err := net.Listen(network, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Listener{l}, nil
+}
+
+// ListenTLS binds to a network address and accepts new TLS-encrypted connections.
+// It returns a Listener which starts new muxado server sessions on the connections.
+func ListenTLS(network, addr string, tlsConfig *tls.Config) (*Listener, error) {
+	l, err := tls.Listen(network, addr, tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Listener{l}, nil
+}
+
+// NewListener creates a new muxado listener which creates new muxado server sessions
+// by accepting connections from the given net.Listener
+func NewListener(l net.Listener) *Listener {
+	return &Listener{l}
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/example/.gitignore
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/example/.gitignore
@@ -1,0 +1,1 @@
+example

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/example/blockhandler/blockhandler.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/example/blockhandler/blockhandler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	ps "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream"
+	pstss "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/spdystream"
 )
 
 func die(err error) {
@@ -17,7 +18,7 @@ func die(err error) {
 
 func main() {
 	// create a new Swarm
-	swarm := ps.NewSwarm()
+	swarm := ps.NewSwarm(pstss.Transport)
 	defer swarm.Close()
 
 	// tell swarm what to do with a new incoming streams.
@@ -62,13 +63,12 @@ func main() {
 	nSndStream := 0
 	for {
 		<-time.After(200 * time.Millisecond)
-		s, err := swarm.NewStreamWithConn(c)
+		_, err := swarm.NewStreamWithConn(c)
 		if err != nil {
 			die(err)
 		}
 		log("sender got new stream %d", nSndStream)
 		nSndStream++
-		s.Wait()
 	}
 }
 

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/example/closer/closer.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/example/closer/closer.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	ps "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream"
+)
+
+func die(err error) {
+	fmt.Fprintf(os.Stderr, "error: %s\n")
+	os.Exit(1)
+}
+
+func main() {
+	// create a new Swarm
+	swarm := ps.NewSwarm()
+	defer swarm.Close()
+
+	// tell swarm what to do with a new incoming streams.
+	// EchoHandler just echos back anything they write.
+	swarm.SetStreamHandler(ps.EchoHandler)
+
+	l, err := net.Listen("tcp", "localhost:8001")
+	if err != nil {
+		die(err)
+	}
+
+	if _, err := swarm.AddListener(l); err != nil {
+		die(err)
+	}
+
+	nc, err := net.Dial("tcp", "localhost:8001")
+	if err != nil {
+		die(err)
+	}
+
+	c, err := swarm.AddConn(nc)
+	if err != nil {
+		die(err)
+	}
+
+	hello := []byte("hello")
+	goodbye := []byte("goodbye")
+	swarm.SetStreamHandler(func(s *ps.Stream) {
+		go func() {
+			log("handler: got new stream.")
+			// s.Wait()
+			// log("handler: done waiting on new stream.")
+			buf := make([]byte, len(hello))
+			s.Read(buf)
+			log("handler: read: %s", buf)
+			s.Write(goodbye)
+			log("handler: wrote: %s", goodbye)
+			s.Close()
+			log("handler: closed.")
+		}()
+	})
+
+	for {
+		s, err := swarm.NewStreamWithConn(c)
+		if err != nil {
+			die(err)
+		}
+		// s.Wait()
+		log("sender: got new stream")
+		for {
+			<-time.After(500 * time.Millisecond)
+			log("sender: writing hello...")
+			if _, err := s.Write(hello); err != nil {
+				log("sender: write error: %s", err)
+				break
+			}
+			buf := make([]byte, len(goodbye))
+			if _, err := s.Read(buf); err != nil {
+				log("sender: read error: %s", err)
+				break
+			}
+		}
+		if err := s.Close(); err != nil {
+			log("sender: close error: %s", err)
+		}
+	}
+}
+
+func log(s string, ifs ...interface{}) {
+	fmt.Fprintf(os.Stderr, s+"\n", ifs...)
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/stream.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/stream.go
@@ -1,7 +1,7 @@
 package peerstream
 
 import (
-	ss "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/spdystream"
+	pst "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport"
 )
 
 // StreamHandler is a function which receives a Stream. It
@@ -15,25 +15,25 @@ type StreamHandler func(s *Stream)
 // Stream is an io.{Read,Write,Close}r to a remote counterpart.
 // It wraps a spdystream.Stream, and links it to a Conn and groups
 type Stream struct {
-	ssStream *ss.Stream
+	pstStream pst.Stream
 
 	conn   *Conn
 	groups groupSet
 }
 
-func newStream(ssS *ss.Stream, c *Conn) *Stream {
+func newStream(ss pst.Stream, c *Conn) *Stream {
 	s := &Stream{
-		conn:     c,
-		ssStream: ssS,
-		groups:   groupSet{m: make(map[Group]struct{})},
+		conn:      c,
+		pstStream: ss,
+		groups:    groupSet{m: make(map[Group]struct{})},
 	}
 	s.groups.AddSet(&c.groups) // inherit groups
 	return s
 }
 
 // SPDYStream returns the underlying *spdystream.Stream
-func (s *Stream) SPDYStream() *ss.Stream {
-	return s.ssStream
+func (s *Stream) Stream() pst.Stream {
+	return s.pstStream
 }
 
 // Conn returns the Conn associated with this Stream
@@ -61,17 +61,12 @@ func (s *Stream) AddGroup(g Group) {
 	s.groups.Add(g)
 }
 
-// Write writes bytes to a stream, calling write data for each call.
-func (s *Stream) Wait() error {
-	return s.ssStream.Wait()
-}
-
 func (s *Stream) Read(p []byte) (n int, err error) {
-	return s.ssStream.Read(p)
+	return s.pstStream.Read(p)
 }
 
 func (s *Stream) Write(p []byte) (n int, err error) {
-	return s.ssStream.Write(p)
+	return s.pstStream.Write(p)
 }
 
 func (s *Stream) Close() error {

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/swarm.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/swarm.go
@@ -4,12 +4,17 @@ import (
 	"errors"
 	"net"
 	"sync"
+
+	pst "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport"
 )
 
 // fd is a (file) descriptor, unix style
 type fd uint32
 
 type Swarm struct {
+	// the transport we'll use.
+	transport pst.Transport
+
 	// active streams.
 	streams    map[*Stream]struct{}
 	streamLock sync.RWMutex
@@ -30,8 +35,9 @@ type Swarm struct {
 	selectConn    SelectConn    // default SelectConn function
 }
 
-func NewSwarm() *Swarm {
+func NewSwarm(t pst.Transport) *Swarm {
 	return &Swarm{
+		transport:     t,
 		streams:       make(map[*Stream]struct{}),
 		conns:         make(map[*Conn]struct{}),
 		listeners:     make(map[*Listener]struct{}),

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/muxado/muxado.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/muxado/muxado.go
@@ -3,7 +3,7 @@ package peerstream_muxado
 import (
 	"net"
 
-	muxado "github.com/inconshreveable/muxado"
+	muxado "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/inconshreveable/muxado"
 	pst "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport"
 )
 

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/muxado/muxado.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/muxado/muxado.go
@@ -1,0 +1,80 @@
+package peerstream_muxado
+
+import (
+	"net"
+
+	muxado "github.com/inconshreveable/muxado"
+	pst "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport"
+)
+
+// stream implements pst.Stream using a ss.Stream
+type stream struct {
+	ms muxado.Stream
+}
+
+func (s *stream) muxadoStream() muxado.Stream {
+	return s.ms
+}
+
+func (s *stream) Read(buf []byte) (int, error) {
+	return s.ms.Read(buf)
+}
+
+func (s *stream) Write(buf []byte) (int, error) {
+	return s.ms.Write(buf)
+}
+
+func (s *stream) Close() error {
+	return s.ms.Close()
+}
+
+// Conn is a connection to a remote peer.
+type conn struct {
+	ms muxado.Session
+}
+
+func (c *conn) muxadoSession() muxado.Session {
+	return c.ms
+}
+
+func (c *conn) Close() error {
+	return c.ms.Close()
+}
+
+// OpenStream creates a new stream.
+func (c *conn) OpenStream() (pst.Stream, error) {
+	s, err := c.ms.Open()
+	if err != nil {
+		return nil, err
+	}
+
+	return &stream{ms: s}, nil
+}
+
+// Serve starts listening for incoming requests and handles them
+// using given StreamHandler
+func (c *conn) Serve(handler pst.StreamHandler) {
+	for { // accept loop
+		s, err := c.ms.Accept()
+		if err != nil {
+			return // err always means closed.
+		}
+		go handler(&stream{ms: s})
+	}
+}
+
+type transport struct{}
+
+// Transport is a go-peerstream transport that constructs
+// spdystream-backed connections.
+var Transport = transport{}
+
+func (t transport) NewConn(nc net.Conn, isServer bool) (pst.Conn, error) {
+	var s muxado.Session
+	if isServer {
+		s = muxado.Server(nc)
+	} else {
+		s = muxado.Client(nc)
+	}
+	return &conn{ms: s}, nil
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/muxado/muxado_test.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/muxado/muxado_test.go
@@ -1,0 +1,11 @@
+package peerstream_muxado
+
+import (
+	"testing"
+
+	psttest "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/test"
+)
+
+func TestMuxadoTransport(t *testing.T) {
+	psttest.SubtestAll(t, Transport)
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/spdystream/spdystream.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/spdystream/spdystream.go
@@ -1,0 +1,89 @@
+package peerstream_spdystream
+
+import (
+	"net"
+	"net/http"
+
+	pst "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport"
+	ss "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/spdystream"
+)
+
+// stream implements pst.Stream using a ss.Stream
+type stream ss.Stream
+
+func (s *stream) spdyStream() *ss.Stream {
+	return (*ss.Stream)(s)
+}
+
+func (s *stream) Read(buf []byte) (int, error) {
+	return s.spdyStream().Read(buf)
+}
+
+func (s *stream) Write(buf []byte) (int, error) {
+	return s.spdyStream().Write(buf)
+}
+
+func (s *stream) Close() error {
+	// Reset is spdystream's full bidirectional close.
+	// We expose bidirectional close as our `Close`.
+	// To close only half of the connection, and use other
+	// spdystream options, just get the stream with:
+	//  ssStream := (*ss.Stream)(stream)
+	return s.spdyStream().Reset()
+}
+
+// Conn is a connection to a remote peer.
+type conn ss.Connection
+
+func (c *conn) spdyConn() *ss.Connection {
+	return (*ss.Connection)(c)
+}
+
+func (c *conn) Close() error {
+	return c.spdyConn().Close()
+}
+
+// OpenStream creates a new stream.
+func (c *conn) OpenStream() (pst.Stream, error) {
+	s, err := c.spdyConn().CreateStream(http.Header{}, nil, false)
+	if err != nil {
+		return nil, err
+	}
+
+	// wait for a response before writing. for some reason
+	// spdystream does not make forward progress unless you do this.
+	s.Wait()
+	return (*stream)(s), nil
+}
+
+// Serve starts listening for incoming requests and handles them
+// using given StreamHandler
+func (c *conn) Serve(handler pst.StreamHandler) {
+	c.spdyConn().Serve(func(s *ss.Stream) {
+
+		// Flow control and backpressure of Opening streams is broken.
+		// I believe that spdystream has one set of workers that both send
+		// data AND accept new streams (as it's just more data). there
+		// is a problem where if the new stream handlers want to throttle,
+		// they also eliminate the ability to read/write data, which makes
+		// forward-progress impossible. Thus, throttling this function is
+		// -- at this moment -- not the solution. Either spdystream must
+		// change, or we must throttle another way. go-peerstream handles
+		// every new stream in its own goroutine.
+		go func() {
+			s.SendReply(http.Header{}, false)
+			handler((*stream)(s))
+		}()
+	})
+}
+
+type transport struct{}
+
+// Transport is a go-peerstream transport that constructs
+// spdystream-backed connections.
+var Transport = transport{}
+
+func (t transport) NewConn(nc net.Conn, isServer bool) (pst.Conn, error) {
+	c, err := ss.NewConnection(nc, isServer)
+	return (*conn)(c), err
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/spdystream/spdystream_test.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/spdystream/spdystream_test.go
@@ -1,0 +1,11 @@
+package peerstream_spdystream
+
+import (
+	"testing"
+
+	psttest "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/test"
+)
+
+func TestSpdyStreamTransport(t *testing.T) {
+	psttest.SubtestAll(t, Transport)
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/test/ttest.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/test/ttest.go
@@ -1,0 +1,438 @@
+package peerstream_transport_test
+
+import (
+	"bytes"
+	crand "crypto/rand"
+	"fmt"
+	"io"
+	mrand "math/rand"
+	"net"
+	"os"
+	"reflect"
+	"runtime"
+	"sync"
+	"testing"
+
+	ps "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream"
+	pst "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport"
+)
+
+var randomness []byte
+var nextPort = 20000
+
+func init() {
+	// read 1MB of randomness
+	randomness = make([]byte, 1<<20)
+	if _, err := crand.Read(randomness); err != nil {
+		panic(err)
+	}
+}
+
+func randBuf(size int) []byte {
+	n := len(randomness) - size
+	if size < 1 {
+		panic(fmt.Errorf("requested too large buffer (%d). max is %d", size, len(randomness)))
+	}
+
+	start := mrand.Intn(n)
+	return randomness[start : start+size]
+}
+
+func checkErr(t *testing.T, err error) {
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func getNextPort() int {
+	nextPort++
+	return nextPort
+}
+
+func log(s string, v ...interface{}) {
+	if testing.Verbose() {
+		fmt.Fprintf(os.Stderr, "> "+s+"\n", v...)
+	}
+}
+
+type echoSetup struct {
+	swarm *ps.Swarm
+	conns []*ps.Conn
+}
+
+func singleConn(t *testing.T, tr pst.Transport) echoSetup {
+	swarm := ps.NewSwarm(tr)
+	swarm.SetStreamHandler(func(s *ps.Stream) {
+		defer s.Close()
+		log("accepted stream")
+		io.Copy(s, s) // echo everything
+		log("closing stream")
+	})
+
+	port := getNextPort()
+	addr := fmt.Sprintf("localhost:%d", port)
+	log("listening at %s", addr)
+	l, err := net.Listen("tcp", addr)
+	checkErr(t, err)
+
+	_, err = swarm.AddListener(l)
+	checkErr(t, err)
+
+	log("dialing to %s", addr)
+	nc1, err := net.Dial("tcp", addr)
+	checkErr(t, err)
+
+	c1, err := swarm.AddConn(nc1)
+	checkErr(t, err)
+
+	return echoSetup{
+		swarm: swarm,
+		conns: []*ps.Conn{c1},
+	}
+}
+
+func makeSwarm(t *testing.T, tr pst.Transport, nListeners int) *ps.Swarm {
+	swarm := ps.NewSwarm(tr)
+	swarm.SetStreamHandler(func(s *ps.Stream) {
+		defer s.Close()
+		log("accepted stream")
+		io.Copy(s, s) // echo everything
+		log("closing stream")
+	})
+
+	for i := 0; i < nListeners; i++ {
+		port := getNextPort()
+		addr := fmt.Sprintf("localhost:%d", port)
+		log("%p listening at %s", swarm, addr)
+		l, err := net.Listen("tcp", addr)
+		checkErr(t, err)
+		_, err = swarm.AddListener(l)
+		checkErr(t, err)
+	}
+
+	return swarm
+}
+
+func makeSwarms(t *testing.T, tr pst.Transport, nSwarms, nListeners int) []*ps.Swarm {
+	swarms := make([]*ps.Swarm, nSwarms)
+	for i := 0; i < nSwarms; i++ {
+		swarms[i] = makeSwarm(t, tr, nListeners)
+	}
+	return swarms
+}
+
+func SubtestConstructSwarm(t *testing.T, tr pst.Transport) {
+	ps.NewSwarm(tr)
+}
+
+func SubtestSimpleWrite(t *testing.T, tr pst.Transport) {
+	swarm := ps.NewSwarm(tr)
+	defer swarm.Close()
+
+	piper, pipew := io.Pipe()
+	swarm.SetStreamHandler(func(s *ps.Stream) {
+		defer s.Close()
+		log("accepted stream")
+		w := io.MultiWriter(s, pipew)
+		io.Copy(w, s) // echo everything and write it to pipew
+		log("closing stream")
+	})
+
+	port := getNextPort()
+	addr := fmt.Sprintf("localhost:%d", port)
+	log("listening at %s", addr)
+	l, err := net.Listen("tcp", addr)
+	checkErr(t, err)
+
+	_, err = swarm.AddListener(l)
+	checkErr(t, err)
+
+	log("dialing to %s", addr)
+	nc1, err := net.Dial("tcp", addr)
+	checkErr(t, err)
+
+	c1, err := swarm.AddConn(nc1)
+	checkErr(t, err)
+	defer c1.Close()
+
+	log("creating stream")
+	s1, err := c1.NewStream()
+	checkErr(t, err)
+	defer s1.Close()
+
+	buf1 := randBuf(4096)
+	log("writing %d bytes to stream", len(buf1))
+	_, err = s1.Write(buf1)
+	checkErr(t, err)
+
+	buf2 := make([]byte, len(buf1))
+	log("reading %d bytes from stream (echoed)", len(buf2))
+	_, err = s1.Read(buf2)
+	checkErr(t, err)
+	if string(buf2) != string(buf1) {
+		t.Error("buf1 and buf2 not equal: %s != %s", string(buf1), string(buf2))
+	}
+
+	buf3 := make([]byte, len(buf1))
+	log("reading %d bytes from pipe (tee)", len(buf3))
+	_, err = piper.Read(buf3)
+	checkErr(t, err)
+	if string(buf3) != string(buf1) {
+		t.Error("buf1 and buf3 not equal: %s != %s", string(buf1), string(buf3))
+	}
+}
+
+func SubtestSimpleWrite100msgs(t *testing.T, tr pst.Transport) {
+
+	msgs := 100
+	msgsize := 1 << 19
+	es := singleConn(t, tr)
+
+	log("creating stream")
+	stream, err := es.conns[0].NewStream()
+	checkErr(t, err)
+
+	bufs := make(chan []byte, msgs)
+	errs := make(chan error, msgs*100)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < msgs; i++ {
+			buf := randBuf(msgsize)
+			bufs <- buf
+			log("writing %d bytes (message %d/%d #%x)", len(buf), i, msgs, buf[:3])
+			if _, err := stream.Write(buf); err != nil {
+				errs <- err
+				continue
+			}
+		}
+		close(bufs)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		buf2 := make([]byte, msgsize)
+		i := 0
+		for buf1 := range bufs {
+			log("reading %d bytes (message %d/%d #%x)", len(buf1), i, msgs, buf1[:3])
+			i++
+
+			if _, err := io.ReadFull(stream, buf2); err != nil {
+				errs <- err
+				continue
+			}
+			if !bytes.Equal(buf1, buf2) {
+				errs <- fmt.Errorf("buffers not equal (%x != %x)", buf1[:3], buf2[:3])
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+func SubtestStressNSwarmNConnNStreamNMsg(t *testing.T, tr pst.Transport, nSwarm, nConn, nStream, nMsg int) {
+
+	msgsize := 1 << 11
+	errs := make(chan error, nSwarm*nConn*nStream*nMsg*100) // dont block anything.
+
+	rateLimitN := 5000
+	rateLimitChan := make(chan struct{}, rateLimitN) // max of 5k funcs.
+	for i := 0; i < rateLimitN; i++ {
+		rateLimitChan <- struct{}{}
+	}
+
+	rateLimit := func(f func()) {
+		<-rateLimitChan
+		f()
+		rateLimitChan <- struct{}{}
+	}
+
+	writeStream := func(s *ps.Stream, bufs chan<- []byte) {
+		log("writeStream %p, %d nMsg", s, nMsg)
+
+		for i := 0; i < nMsg; i++ {
+			buf := randBuf(msgsize)
+			bufs <- buf
+			log("%p writing %d bytes (message %d/%d #%x)", s, len(buf), i, nMsg, buf[:3])
+			if _, err := s.Write(buf); err != nil {
+				errs <- err
+				continue
+			}
+		}
+	}
+
+	readStream := func(s *ps.Stream, bufs <-chan []byte) {
+		log("readStream %p, %d nMsg", s, nMsg)
+
+		buf2 := make([]byte, msgsize)
+		i := 0
+		for buf1 := range bufs {
+			log("%p reading %d bytes (message %d/%d #%x)", s, len(buf1), i, nMsg, buf1[:3])
+			i++
+
+			if _, err := io.ReadFull(s, buf2); err != nil {
+				errs <- err
+				continue
+			}
+			if !bytes.Equal(buf1, buf2) {
+				errs <- fmt.Errorf("buffers not equal (%x != %x)", buf1[:3], buf2[:3])
+			}
+		}
+	}
+
+	openStreamAndRW := func(c *ps.Conn) {
+		log("openStreamAndRW %p, %d nMsg", c, nMsg)
+
+		s, err := c.NewStream()
+		if err != nil {
+			errs <- fmt.Errorf("Failed to create NewStream: %s", err)
+			return
+		}
+
+		bufs := make(chan []byte, nMsg)
+		go func() {
+			writeStream(s, bufs)
+			close(bufs)
+		}()
+
+		readStream(s, bufs)
+		s.Close()
+	}
+
+	openConnAndRW := func(a, b *ps.Swarm) {
+		log("openConnAndRW %p -> %p, %d nStream", a, b, nConn)
+
+		ls := b.Listeners()
+		l := ls[mrand.Intn(len(ls))]
+		nl := l.NetListener()
+		nla := nl.Addr()
+
+		nc, err := net.Dial(nla.Network(), nla.String())
+		if err != nil {
+			errs <- err
+			return
+		}
+
+		c, err := a.AddConn(nc)
+		if err != nil {
+			errs <- err
+			return
+		}
+
+		var wg sync.WaitGroup
+		for i := 0; i < nStream; i++ {
+			wg.Add(1)
+			go rateLimit(func() {
+				defer wg.Done()
+				openStreamAndRW(c)
+			})
+		}
+		wg.Wait()
+		c.Close()
+	}
+
+	openConnsAndRW := func(a, b *ps.Swarm) {
+		log("openConnsAndRW %p -> %p, %d conns", a, b, nConn)
+
+		var wg sync.WaitGroup
+		for i := 0; i < nConn; i++ {
+			wg.Add(1)
+			go rateLimit(func() {
+				defer wg.Done()
+				openConnAndRW(a, b)
+			})
+		}
+		wg.Wait()
+	}
+
+	connectSwarmsAndRW := func(swarms []*ps.Swarm) {
+		log("connectSwarmsAndRW %d swarms", len(swarms))
+
+		var wg sync.WaitGroup
+		for _, a := range swarms {
+			for _, b := range swarms {
+				wg.Add(1)
+				go rateLimit(func() {
+					defer wg.Done()
+					openConnsAndRW(a, b)
+				})
+			}
+		}
+		wg.Wait()
+	}
+
+	swarms := makeSwarms(t, tr, nSwarm, 3) // 3 listeners per swarm.
+
+	go func() {
+		connectSwarmsAndRW(swarms)
+		close(errs) // done
+	}()
+
+	for err := range errs {
+		t.Error(err)
+	}
+
+}
+
+func SubtestStress1Swarm1Conn1Stream1Msg(t *testing.T, tr pst.Transport) {
+	SubtestStressNSwarmNConnNStreamNMsg(t, tr, 1, 1, 1, 1)
+}
+
+func SubtestStress1Swarm1Conn1Stream100Msg(t *testing.T, tr pst.Transport) {
+	SubtestStressNSwarmNConnNStreamNMsg(t, tr, 1, 1, 1, 100)
+}
+
+func SubtestStress1Swarm1Conn100Stream100Msg(t *testing.T, tr pst.Transport) {
+	SubtestStressNSwarmNConnNStreamNMsg(t, tr, 1, 1, 100, 100)
+}
+
+func SubtestStress1Swarm10Conn50Stream50Msg(t *testing.T, tr pst.Transport) {
+	SubtestStressNSwarmNConnNStreamNMsg(t, tr, 1, 10, 50, 50)
+}
+
+func SubtestStress5Swarm2Conn20Stream20Msg(t *testing.T, tr pst.Transport) {
+	SubtestStressNSwarmNConnNStreamNMsg(t, tr, 5, 2, 20, 20)
+}
+
+func SubtestStress10Swarm2Conn100Stream100Msg(t *testing.T, tr pst.Transport) {
+	SubtestStressNSwarmNConnNStreamNMsg(t, tr, 10, 2, 100, 100)
+}
+
+func SubtestAll(t *testing.T, tr pst.Transport) {
+
+	tests := []TransportTest{
+		SubtestConstructSwarm,
+		SubtestSimpleWrite,
+		SubtestSimpleWrite100msgs,
+		SubtestStress1Swarm1Conn1Stream1Msg,
+		SubtestStress1Swarm1Conn1Stream100Msg,
+		SubtestStress1Swarm1Conn100Stream100Msg,
+		SubtestStress1Swarm10Conn50Stream50Msg,
+		SubtestStress5Swarm2Conn20Stream20Msg,
+		// SubtestStress10Swarm2Conn100Stream100Msg, <-- this hoses the osx network stack...
+	}
+
+	for _, f := range tests {
+		if testing.Verbose() {
+			fmt.Fprintf(os.Stderr, "==== RUN %s\n", GetFunctionName(f))
+		}
+		f(t, tr)
+	}
+}
+
+type TransportTest func(t *testing.T, tr pst.Transport)
+
+func TestNoOp(t *testing.T) {}
+
+func GetFunctionName(i interface{}) string {
+	return runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/transport.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/transport.go
@@ -1,0 +1,36 @@
+package peerstream_transport
+
+import (
+	"io"
+	"net"
+)
+
+// Stream is a bidirectional io pipe within a connection
+type Stream interface {
+	io.Reader
+	io.Writer
+	io.Closer
+}
+
+// StreamHandler is a function that handles streams
+// (usually those opened by the remote side)
+type StreamHandler func(Stream)
+
+// Conn is a stream-multiplexing connection to a remote peer.
+type Conn interface {
+	io.Closer
+
+	// OpenStream creates a new stream.
+	OpenStream() (Stream, error)
+
+	// Serve starts listening for incoming requests and handles them
+	// using given StreamHandler
+	Serve(StreamHandler)
+}
+
+// Transport constructs go-peerstream compatible connections.
+type Transport interface {
+
+	// NewConn constructs a new connection
+	NewConn(c net.Conn, isServer bool) (Conn, error)
+}

--- a/net/mux.go
+++ b/net/mux.go
@@ -89,34 +89,19 @@ func (m *Mux) SetHandler(p ProtocolID, h StreamHandler) {
 
 // Handle reads the next name off the Stream, and calls a function
 func (m *Mux) Handle(s Stream) {
+	ctx := context.Background()
 
-	// Flow control and backpressure of Opening streams is broken.
-	// I believe that spdystream has one set of workers that both send
-	// data AND accept new streams (as it's just more data). there
-	// is a problem where if the new stream handlers want to throttle,
-	// they also eliminate the ability to read/write data, which makes
-	// forward-progress impossible. Thus, throttling this function is
-	// -- at this moment -- not the solution. Either spdystream must
-	// change, or we must throttle another way.
-	//
-	// In light of this, we use a goroutine for now (otherwise the
-	// spdy worker totally blocks, and we can't even read the protocol
-	// header). The better route in the future is to use a worker pool.
-	go func() {
-		ctx := context.Background()
+	name, handler, err := m.ReadProtocolHeader(s)
+	if err != nil {
+		err = fmt.Errorf("protocol mux error: %s", err)
+		log.Error(err)
+		log.Event(ctx, "muxError", lgbl.Error(err))
+		return
+	}
 
-		name, handler, err := m.ReadProtocolHeader(s)
-		if err != nil {
-			err = fmt.Errorf("protocol mux error: %s", err)
-			log.Error(err)
-			log.Event(ctx, "muxError", lgbl.Error(err))
-			return
-		}
-
-		log.Info("muxer handle protocol: %s", name)
-		log.Event(ctx, "muxHandle", eventlog.Metadata{"protocol": name})
-		handler(s)
-	}()
+	log.Info("muxer handle protocol: %s", name)
+	log.Event(ctx, "muxHandle", eventlog.Metadata{"protocol": name})
+	handler(s)
 }
 
 // ReadLengthPrefix reads the name from Reader with a length-byte-prefix.

--- a/net/swarm/swarm.go
+++ b/net/swarm/swarm.go
@@ -10,6 +10,7 @@ import (
 	ctxgroup "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-ctxgroup"
 	ma "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 	ps "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream"
+	psss "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/spdystream"
 )
 
 var log = eventlog.Logger("swarm2")
@@ -34,7 +35,7 @@ func NewSwarm(ctx context.Context, listenAddrs []ma.Multiaddr,
 	local peer.ID, peers peer.Peerstore) (*Swarm, error) {
 
 	s := &Swarm{
-		swarm: ps.NewSwarm(),
+		swarm: ps.NewSwarm(psss.Transport),
 		local: local,
 		peers: peers,
 		cg:    ctxgroup.WithContext(ctx),

--- a/net/swarm/swarm.go
+++ b/net/swarm/swarm.go
@@ -10,10 +10,14 @@ import (
 	ctxgroup "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-ctxgroup"
 	ma "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 	ps "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream"
+	psmux "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/muxado"
 	psss "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/spdystream"
 )
 
 var log = eventlog.Logger("swarm2")
+
+var _ = psss.Transport
+var PSTransport = psmux.Transport
 
 // Swarm is a connection muxer, allowing connections to other peers to
 // be opened and closed, while still using the same Chan for all
@@ -35,7 +39,7 @@ func NewSwarm(ctx context.Context, listenAddrs []ma.Multiaddr,
 	local peer.ID, peers peer.Peerstore) (*Swarm, error) {
 
 	s := &Swarm{
-		swarm: ps.NewSwarm(psss.Transport),
+		swarm: ps.NewSwarm(PSTransport),
 		local: local,
 		peers: peers,
 		cg:    ctxgroup.WithContext(ctx),

--- a/net/swarm/swarm_stream.go
+++ b/net/swarm/swarm_stream.go
@@ -22,11 +22,6 @@ func (s *Stream) Conn() *Conn {
 	return (*Conn)(s.Stream().Conn())
 }
 
-// Wait waits for the stream to receive a reply.
-func (s *Stream) Wait() error {
-	return s.Stream().Wait()
-}
-
 // Read reads bytes from a stream.
 func (s *Stream) Read(p []byte) (n int, err error) {
 	return s.Stream().Read(p)

--- a/net/swarm/swarm_test.go
+++ b/net/swarm/swarm_test.go
@@ -139,7 +139,10 @@ func SubtestSwarm(t *testing.T, SwarmNum int, MsgNum int) {
 				for k := 0; k < MsgNum; k++ { // with k messages
 					msg := "ping"
 					log.Debugf("%s %s %s (%d)", s1.local, msg, p, k)
-					stream.Write([]byte(msg))
+					if _, err := stream.Write([]byte(msg)); err != nil {
+						errChan <- err
+						continue
+					}
 				}
 
 				// read it later
@@ -200,7 +203,7 @@ func SubtestSwarm(t *testing.T, SwarmNum int, MsgNum int) {
 		// check any errors (blocks till consumer is done)
 		for err := range errChan {
 			if err != nil {
-				t.Fatal(err.Error())
+				t.Error(err.Error())
 			}
 		}
 


### PR DESCRIPTION
This PR updates go-peerstream to the new abstracted
transport version. It also changes the default transport
to http://github.com/inconshreveable/muxado

@whyrusleeping: try out this branch with provider fixes
and see if it gets rid of the hang you were experiencing.
If not, the problem's on our side.