### PR TITLE
fix(bitswap/network): return when context is done

### DIFF
--- a/exchange/bitswap/network/ipfs_impl.go
+++ b/exchange/bitswap/network/ipfs_impl.go
@@ -107,6 +107,7 @@ func (bsnet *impl) FindProvidersAsync(ctx context.Context, k util.Key, max int) 
 			bsnet.host.Peerstore().AddAddresses(info.ID, info.Addrs)
 			select {
 			case <-ctx.Done():
+				return
 			case out <- info.ID:
 			}
 		}


### PR DESCRIPTION
@jbenet @whyrusleeping 

Fairly certain this'll cause the client worker to hang.