### PR TITLE
sharness bootstrap rm

### DIFF
--- a/test/lib/test-lib.sh
+++ b/test/lib/test-lib.sh
@@ -74,7 +74,8 @@ test_init_ipfs() {
 	test_expect_success "prepare config" '
 		mkdir mountdir ipfs ipns &&
 		ipfs config Mounts.IPFS "$(pwd)/ipfs" &&
-		ipfs config Mounts.IPNS "$(pwd)/ipns"
+		ipfs config Mounts.IPNS "$(pwd)/ipns" &&
+		ipfs bootstrap rm --all
 	'
 
 }

--- a/test/lib/test-lib.sh
+++ b/test/lib/test-lib.sh
@@ -96,7 +96,10 @@ test_launch_ipfs_daemon() {
 
 test_mount_ipfs() {
 
+	# make sure stuff is unmounted first.
 	test_expect_success FUSE "'ipfs mount' succeeds" '
+		umount $(pwd)/ipfs || true &&
+		umount $(pwd)/ipns || true &&
 		ipfs mount >actual
 	'
 

--- a/test/t0060-daemon.sh
+++ b/test/t0060-daemon.sh
@@ -11,7 +11,7 @@ test_description="Test daemon command"
 
 . lib/test-lib.sh
 
-
+# NOTE: this should remove bootstrap peers (needs a flag)
 test_expect_success "ipfs daemon --init launches" '
   export IPFS_DIR="$(pwd)/.go-ipfs" &&
   ipfs daemon --init 2>&1 >actual_init &


### PR DESCRIPTION
this PR:
- `ipfs bootstrap rm` args now optional. (no-op)
- adds `ipfs bootstrap rm --all` option
- makes sharness remove bootstrap nodes