### PR TITLE
bootstrap add --default option

### DIFF
--- a/cmd/ipfs/init.go
+++ b/cmd/ipfs/init.go
@@ -12,6 +12,7 @@ import (
 	cmds "github.com/jbenet/go-ipfs/commands"
 	config "github.com/jbenet/go-ipfs/config"
 	core "github.com/jbenet/go-ipfs/core"
+	corecmds "github.com/jbenet/go-ipfs/core/commands"
 	imp "github.com/jbenet/go-ipfs/importer"
 	chunk "github.com/jbenet/go-ipfs/importer/chunk"
 	ci "github.com/jbenet/go-ipfs/p2p/crypto"
@@ -179,6 +180,11 @@ func initConfig(configFilename string, dspathOverride string, nBitsForKeypair in
 		return nil, err
 	}
 
+	bootstrapPeers, err := corecmds.DefaultBootstrapPeers()
+	if err != nil {
+		return nil, err
+	}
+
 	conf := &config.Config{
 
 		// setup the node's default addresses.
@@ -191,39 +197,10 @@ func initConfig(configFilename string, dspathOverride string, nBitsForKeypair in
 			API: "/ip4/127.0.0.1/tcp/5001",
 		},
 
-		Bootstrap: []*config.BootstrapPeer{
-			&config.BootstrapPeer{ // Use these hardcoded bootstrap peers for now.
-				// mars.i.ipfs.io
-				PeerID:  "QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
-				Address: "/ip4/104.131.131.82/tcp/4001",
-			},
-			&config.BootstrapPeer{
-				// Neptune
-				PeerID:  "QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z",
-				Address: "/ip4/104.236.176.52/tcp/4001",
-			},
-			&config.BootstrapPeer{
-				// Pluto
-				PeerID:  "QmSoLpPVmHKQ4XTPdz8tjDFgdeRFkpV8JgYq8JVJ69RrZm",
-				Address: "/ip4/104.236.179.241/tcp/4001",
-			},
-			&config.BootstrapPeer{
-				// Uranus
-				PeerID:  "QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm",
-				Address: "/ip4/162.243.248.213/tcp/4001",
-			},
-			&config.BootstrapPeer{
-				// Saturn
-				PeerID:  "QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu",
-				Address: "/ip4/128.199.219.111/tcp/4001",
-			},
-		},
-
+		Bootstrap: bootstrapPeers,
 		Datastore: ds,
-
-		Logs: logConfig,
-
-		Identity: identity,
+		Logs:      logConfig,
+		Identity:  identity,
 
 		// setup the node mount points.
 		Mounts: config.Mounts{

--- a/core/bootstrap.go
+++ b/core/bootstrap.go
@@ -29,7 +29,7 @@ func superviseConnections(parent context.Context,
 	h host.Host,
 	route *dht.IpfsDHT, // TODO depend on abstract interface for testing purposes
 	store peer.Peerstore,
-	peers []*config.BootstrapPeer) error {
+	peers []config.BootstrapPeer) error {
 
 	for {
 		ctx, _ := context.WithTimeout(parent, connectiontimeout)
@@ -51,7 +51,7 @@ func bootstrap(ctx context.Context,
 	h host.Host,
 	r *dht.IpfsDHT,
 	ps peer.Peerstore,
-	boots []*config.BootstrapPeer) error {
+	boots []config.BootstrapPeer) error {
 
 	connectedPeers := h.Network().Peers()
 	if len(connectedPeers) >= recoveryThreshold {
@@ -137,7 +137,7 @@ func connect(ctx context.Context, ps peer.Peerstore, r *dht.IpfsDHT, peers []pee
 	return nil
 }
 
-func toPeer(bootstrap *config.BootstrapPeer) (p peer.PeerInfo, err error) {
+func toPeer(bootstrap config.BootstrapPeer) (p peer.PeerInfo, err error) {
 	id, err := peer.IDB58Decode(bootstrap.PeerID)
 	if err != nil {
 		return


### PR DESCRIPTION
this commit adds the "bootstrap add --default" option,
which adds back hardcoded bootstrap peers. this makes it
easy to test ipfs with different bootstrap nodes:

    ipfs bootstrap rm --all
    ipfs bootstrap add <peer-addr>
    <testing to your satisfaction>
    ipfs bootstrap rm --all
    ipfs bootstrap add --default