### PR TITLE
Command channel output 

### DIFF
--- a/commands/channelmarshaler.go
+++ b/commands/channelmarshaler.go
@@ -1,0 +1,34 @@
+package commands
+
+import "io"
+
+type ChannelMarshaler struct {
+	Channel   <-chan interface{}
+	Marshaler func(interface{}) (io.Reader, error)
+
+	reader io.Reader
+}
+
+func (cr *ChannelMarshaler) Read(p []byte) (int, error) {
+	if cr.reader == nil {
+		val, more := <-cr.Channel
+		if !more {
+			return 0, io.EOF
+		}
+
+		r, err := cr.Marshaler(val)
+		if err != nil {
+			return 0, err
+		}
+		cr.reader = r
+	}
+
+	n, err := cr.reader.Read(p)
+	if err != nil && err != io.EOF {
+		return n, err
+	}
+	if n == 0 {
+		cr.reader = nil
+	}
+	return n, nil
+}

--- a/commands/command.go
+++ b/commands/command.go
@@ -114,14 +114,17 @@ func (c *Command) Call(req Request) Response {
 		return res
 	}
 
-	actualType := reflect.ValueOf(output).Type()
+	actualType := reflect.TypeOf(output)
+	if actualType.Kind() == reflect.Ptr {
+		actualType = actualType.Elem()
+	}
 
 	// test if output is a channel
 	isChan := actualType.Kind() == reflect.Chan
 
 	// If the command specified an output type, ensure the actual value returned is of that type
 	if cmd.Type != nil && !isChan {
-		expectedType := reflect.ValueOf(cmd.Type).Type()
+		expectedType := reflect.TypeOf(cmd.Type)
 
 		if actualType != expectedType {
 			res.SetError(ErrIncorrectType, ErrNormal)

--- a/commands/command.go
+++ b/commands/command.go
@@ -114,13 +114,16 @@ func (c *Command) Call(req Request) Response {
 		return res
 	}
 
+	isChan := false
 	actualType := reflect.TypeOf(output)
-	if actualType.Kind() == reflect.Ptr {
-		actualType = actualType.Elem()
-	}
+	if actualType != nil {
+		if actualType.Kind() == reflect.Ptr {
+			actualType = actualType.Elem()
+		}
 
-	// test if output is a channel
-	isChan := actualType.Kind() == reflect.Chan
+		// test if output is a channel
+		isChan = actualType.Kind() == reflect.Chan
+	}
 
 	// If the command specified an output type, ensure the actual value returned is of that type
 	if cmd.Type != nil && !isChan {

--- a/commands/command.go
+++ b/commands/command.go
@@ -135,14 +135,6 @@ func (c *Command) Call(req Request) Response {
 		}
 	}
 
-	// clean up the request (close the readers, e.g. fileargs)
-	// NOTE: this means commands can't expect to keep reading after cmd.Run returns (in a goroutine)
-	err = req.Cleanup()
-	if err != nil {
-		res.SetError(err, ErrNormal)
-		return res
-	}
-
 	res.SetOutput(output)
 	return res
 }

--- a/commands/http/client.go
+++ b/commands/http/client.go
@@ -42,6 +42,9 @@ func (c *client) Send(req cmds.Request) (cmds.Response, error) {
 	// override with json to send to server
 	req.SetOption(cmds.EncShort, cmds.JSON)
 
+	// stream channel output
+	req.SetOption(cmds.ChanOpt, "true")
+
 	query, err := getQuery(req)
 	if err != nil {
 		return nil, err

--- a/commands/http/client.go
+++ b/commands/http/client.go
@@ -150,10 +150,12 @@ func getResponse(httpRes *http.Response, req cmds.Request) (cmds.Response, error
 
 			for {
 				err := dec.Decode(&v)
-				if err != nil {
-					if err != io.EOF {
-						fmt.Println(err.Error())
-					}
+				if err != nil && err != io.EOF {
+					fmt.Println(err.Error())
+					return
+				}
+				if err == io.EOF {
+					close(outChan)
 					return
 				}
 				outChan <- v

--- a/commands/http/client.go
+++ b/commands/http/client.go
@@ -150,11 +150,11 @@ func getResponse(httpRes *http.Response, req cmds.Request) (cmds.Response, error
 		outChan := make(chan interface{})
 		go func() {
 			dec := json.NewDecoder(httpRes.Body)
-			outputType := reflect.ValueOf(req.Command().Type).Type()
-			v := reflect.New(outputType).Interface()
+			outputType := reflect.TypeOf(req.Command().Type)
 
 			for {
-				err := dec.Decode(&v)
+				v := reflect.New(outputType).Interface()
+				err := dec.Decode(v)
 				if err != nil && err != io.EOF {
 					fmt.Println(err.Error())
 					return
@@ -199,8 +199,9 @@ func getResponse(httpRes *http.Response, req cmds.Request) (cmds.Response, error
 		res.SetError(e, e.Code)
 
 	} else {
-		v := req.Command().Type
-		err = dec.Decode(&v)
+		outputType := reflect.TypeOf(req.Command().Type)
+		v := reflect.New(outputType).Interface()
+		err = dec.Decode(v)
 		if err != nil && err != io.EOF {
 			return nil, err
 		}

--- a/commands/http/client.go
+++ b/commands/http/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 
 	cmds "github.com/jbenet/go-ipfs/commands"
@@ -149,7 +150,8 @@ func getResponse(httpRes *http.Response, req cmds.Request) (cmds.Response, error
 		outChan := make(chan interface{})
 		go func() {
 			dec := json.NewDecoder(httpRes.Body)
-			v := req.Command().Type
+			outputType := reflect.ValueOf(req.Command().Type).Type()
+			v := reflect.New(outputType).Interface()
 
 			for {
 				err := dec.Decode(&v)

--- a/commands/option.go
+++ b/commands/option.go
@@ -158,15 +158,18 @@ const (
 	EncLong  = "encoding"
 	RecShort = "r"
 	RecLong  = "recursive"
+	ChanOpt  = "stream-channels"
 )
 
 // options that are used by this package
 var OptionEncodingType = StringOption(EncShort, EncLong, "The encoding type the output should be encoded with (json, xml, or text)")
 var OptionRecursivePath = BoolOption(RecShort, RecLong, "Add directory paths recursively")
+var OptionStreamChannels = BoolOption(ChanOpt, "Stream channel output")
 
 // global options, added to every command
 var globalOptions = []Option{
 	OptionEncodingType,
+	OptionStreamChannels,
 }
 
 // the above array of Options, wrapped in a Command

--- a/commands/request.go
+++ b/commands/request.go
@@ -70,7 +70,6 @@ type Request interface {
 	Context() *Context
 	SetContext(Context)
 	Command() *Command
-	Cleanup() error
 
 	ConvertOptions() error
 }
@@ -172,11 +171,6 @@ func (r *request) SetContext(ctx Context) {
 
 func (r *request) Command() *Command {
 	return r.cmd
-}
-
-func (r *request) Cleanup() error {
-	// TODO
-	return nil
 }
 
 type converter func(string) (interface{}, error)

--- a/commands/response.go
+++ b/commands/response.go
@@ -160,7 +160,14 @@ func (r *response) Marshal() (io.Reader, error) {
 		}
 	}
 
-	return marshaller(r)
+	output, err := marshaller(r)
+	if err != nil {
+		return nil, err
+	}
+	if output == nil {
+		return bytes.NewReader([]byte{}), nil
+	}
+	return output, nil
 }
 
 // Reader returns an `io.Reader` representing marshalled output of this Response

--- a/commands/response_test.go
+++ b/commands/response_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"testing"
@@ -27,21 +28,25 @@ func TestMarshalling(t *testing.T) {
 
 	req.SetOption(EncShort, JSON)
 
-	bytes, err := res.Marshal()
+	reader, err := res.Marshal()
 	if err != nil {
 		t.Error(err, "Should have passed")
 	}
-	output := string(bytes)
+	var buf bytes.Buffer
+	buf.ReadFrom(reader)
+	output := buf.String()
 	if removeWhitespace(output) != "{\"Foo\":\"beep\",\"Bar\":\"boop\",\"Baz\":1337}" {
 		t.Error("Incorrect JSON output")
 	}
 
 	res.SetError(fmt.Errorf("Oops!"), ErrClient)
-	bytes, err = res.Marshal()
+	reader, err = res.Marshal()
 	if err != nil {
 		t.Error("Should have passed")
 	}
-	output = string(bytes)
+	buf.Reset()
+	buf.ReadFrom(reader)
+	output = buf.String()
 	fmt.Println(removeWhitespace(output))
 	if removeWhitespace(output) != "{\"Message\":\"Oops!\",\"Code\":1}" {
 		t.Error("Incorrect JSON output")

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -76,7 +76,7 @@ remains to be implemented.
 		return added, nil
 	},
 	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) ([]byte, error) {
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			val, ok := res.Output().(*AddOutput)
 			if !ok {
 				return nil, u.ErrCast()
@@ -93,7 +93,7 @@ remains to be implemented.
 					buf.Write([]byte(fmt.Sprintf("added %s %s\n", obj.Hash, val.Names[i])))
 				}
 			}
-			return buf.Bytes(), nil
+			return &buf, nil
 		},
 	},
 	Type: &AddOutput{},

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -102,7 +102,7 @@ remains to be implemented.
 			}, nil
 		},
 	},
-	Type: &AddedObject{},
+	Type: AddedObject{},
 }
 
 func add(n *core.IpfsNode, readers []io.Reader) ([]*dag.Node, error) {

--- a/core/commands/block.go
+++ b/core/commands/block.go
@@ -123,7 +123,7 @@ It reads from stdin, and <key> is a base58 encoded multihash.
 			Length: len(data),
 		}, nil
 	},
-	Type: &Block{},
+	Type: Block{},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			block := res.Output().(*Block)

--- a/core/commands/block.go
+++ b/core/commands/block.go
@@ -2,7 +2,9 @@ package commands
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
+	"strings"
 	"time"
 
 	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
@@ -123,9 +125,9 @@ It reads from stdin, and <key> is a base58 encoded multihash.
 	},
 	Type: &Block{},
 	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) ([]byte, error) {
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			block := res.Output().(*Block)
-			return []byte(block.Key + "\n"), nil
+			return strings.NewReader(block.Key + "\n"), nil
 		},
 	},
 }

--- a/core/commands/bootstrap.go
+++ b/core/commands/bootstrap.go
@@ -114,7 +114,7 @@ in the bootstrap list).
 	},
 	Type: &BootstrapOutput{},
 	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) ([]byte, error) {
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			v, ok := res.Output().(*BootstrapOutput)
 			if !ok {
 				return nil, u.ErrCast()
@@ -122,7 +122,7 @@ in the bootstrap list).
 
 			var buf bytes.Buffer
 			err := bootstrapWritePeers(&buf, "added ", v.Peers)
-			return buf.Bytes(), err
+			return &buf, err
 		},
 	},
 }
@@ -175,7 +175,7 @@ var bootstrapRemoveCmd = &cmds.Command{
 	},
 	Type: &BootstrapOutput{},
 	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) ([]byte, error) {
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			v, ok := res.Output().(*BootstrapOutput)
 			if !ok {
 				return nil, u.ErrCast()
@@ -183,7 +183,7 @@ var bootstrapRemoveCmd = &cmds.Command{
 
 			var buf bytes.Buffer
 			err := bootstrapWritePeers(&buf, "removed ", v.Peers)
-			return buf.Bytes(), err
+			return &buf, err
 		},
 	},
 }
@@ -209,7 +209,7 @@ var bootstrapListCmd = &cmds.Command{
 	},
 }
 
-func bootstrapMarshaler(res cmds.Response) ([]byte, error) {
+func bootstrapMarshaler(res cmds.Response) (io.Reader, error) {
 	v, ok := res.Output().(*BootstrapOutput)
 	if !ok {
 		return nil, u.ErrCast()
@@ -217,7 +217,7 @@ func bootstrapMarshaler(res cmds.Response) ([]byte, error) {
 
 	var buf bytes.Buffer
 	err := bootstrapWritePeers(&buf, "", v.Peers)
-	return buf.Bytes(), err
+	return &buf, err
 }
 
 func bootstrapWritePeers(w io.Writer, prefix string, peers []config.BootstrapPeer) error {

--- a/core/commands/bootstrap.go
+++ b/core/commands/bootstrap.go
@@ -112,7 +112,7 @@ in the bootstrap list).
 
 		return &BootstrapOutput{added}, nil
 	},
-	Type: &BootstrapOutput{},
+	Type: BootstrapOutput{},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			v, ok := res.Output().(*BootstrapOutput)
@@ -173,7 +173,7 @@ var bootstrapRemoveCmd = &cmds.Command{
 
 		return &BootstrapOutput{removed}, nil
 	},
-	Type: &BootstrapOutput{},
+	Type: BootstrapOutput{},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			v, ok := res.Output().(*BootstrapOutput)
@@ -203,7 +203,7 @@ var bootstrapListCmd = &cmds.Command{
 		peers := cfg.Bootstrap
 		return &BootstrapOutput{peers}, nil
 	},
-	Type: &BootstrapOutput{},
+	Type: BootstrapOutput{},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: bootstrapMarshaler,
 	},

--- a/core/commands/commands.go
+++ b/core/commands/commands.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"io"
 	"sort"
 
 	cmds "github.com/jbenet/go-ipfs/commands"
@@ -26,13 +27,13 @@ func CommandsCmd(root *cmds.Command) *cmds.Command {
 			return &root, nil
 		},
 		Marshalers: cmds.MarshalerMap{
-			cmds.Text: func(res cmds.Response) ([]byte, error) {
+			cmds.Text: func(res cmds.Response) (io.Reader, error) {
 				v := res.Output().(*Command)
 				var buf bytes.Buffer
 				for _, s := range cmdPathStrings(v) {
 					buf.Write([]byte(s + "\n"))
 				}
-				return buf.Bytes(), nil
+				return &buf, nil
 			},
 		},
 		Type: &Command{},

--- a/core/commands/commands.go
+++ b/core/commands/commands.go
@@ -36,7 +36,7 @@ func CommandsCmd(root *cmds.Command) *cmds.Command {
 				return &buf, nil
 			},
 		},
-		Type: &Command{},
+		Type: Command{},
 	}
 }
 

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -72,7 +72,7 @@ Set the value of the 'datastore.path' key:
 		}
 	},
 	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) ([]byte, error) {
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			if len(res.Request().Arguments()) == 2 {
 				return nil, nil // dont output anything
 			}
@@ -92,7 +92,7 @@ Set the value of the 'datastore.path' key:
 				return nil, err
 			}
 			buf = append(buf, byte('\n'))
-			return buf, nil
+			return bytes.NewReader(buf), nil
 		},
 	},
 	Type: &ConfigField{},

--- a/core/commands/config.go
+++ b/core/commands/config.go
@@ -95,7 +95,7 @@ Set the value of the 'datastore.path' key:
 			return bytes.NewReader(buf), nil
 		},
 	},
-	Type: &ConfigField{},
+	Type: ConfigField{},
 	Subcommands: map[string]*cmds.Command{
 		"show": configShowCmd,
 		"edit": configEditCmd,

--- a/core/commands/diag.go
+++ b/core/commands/diag.go
@@ -86,7 +86,7 @@ connected peers and latencies between them.
 	},
 	Type: &DiagnosticOutput{},
 	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(r cmds.Response) ([]byte, error) {
+		cmds.Text: func(r cmds.Response) (io.Reader, error) {
 			output, ok := r.Output().(*DiagnosticOutput)
 			if !ok {
 				return nil, util.ErrCast()
@@ -96,7 +96,7 @@ connected peers and latencies between them.
 			if err != nil {
 				return nil, err
 			}
-			return buf.Bytes(), nil
+			return &buf, nil
 		},
 	},
 }

--- a/core/commands/diag.go
+++ b/core/commands/diag.go
@@ -84,7 +84,7 @@ connected peers and latencies between them.
 
 		return &DiagnosticOutput{output}, nil
 	},
-	Type: &DiagnosticOutput{},
+	Type: DiagnosticOutput{},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: func(r cmds.Response) (io.Reader, error) {
 			output, ok := r.Output().(*DiagnosticOutput)

--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -91,7 +91,7 @@ if no peer is specified, prints out local peers info.
 			return bytes.NewReader(marshaled), nil
 		},
 	},
-	Type: &IdOutput{},
+	Type: IdOutput{},
 }
 
 func printPeer(ps peer.Peerstore, p peer.ID) (interface{}, error) {

--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -1,9 +1,11 @@
 package commands
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io"
 	"time"
 
 	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
@@ -76,13 +78,17 @@ if no peer is specified, prints out local peers info.
 		return printPeer(node.Peerstore, p.ID)
 	},
 	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) ([]byte, error) {
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			val, ok := res.Output().(*IdOutput)
 			if !ok {
 				return nil, u.ErrCast()
 			}
 
-			return json.MarshalIndent(val, "", "\t")
+			marshaled, err := json.MarshalIndent(val, "", "\t")
+			if err != nil {
+				return nil, err
+			}
+			return bytes.NewReader(marshaled), nil
 		},
 	},
 	Type: &IdOutput{},

--- a/core/commands/log.go
+++ b/core/commands/log.go
@@ -48,5 +48,5 @@ output of a running daemon.
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: MessageTextMarshaler,
 	},
-	Type: &MessageOutput{},
+	Type: MessageOutput{},
 }

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"fmt"
+	"io"
+	"strings"
 
 	cmds "github.com/jbenet/go-ipfs/commands"
 	merkledag "github.com/jbenet/go-ipfs/merkledag"
@@ -70,7 +72,7 @@ it contains, with the following format:
 		return &LsOutput{output}, nil
 	},
 	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) ([]byte, error) {
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			s := ""
 			output := res.Output().(*LsOutput).Objects
 
@@ -84,7 +86,7 @@ it contains, with the following format:
 				}
 			}
 
-			return []byte(s), nil
+			return strings.NewReader(s), nil
 		},
 	},
 	Type: &LsOutput{},

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -89,7 +89,7 @@ it contains, with the following format:
 			return strings.NewReader(s), nil
 		},
 	},
-	Type: &LsOutput{},
+	Type: LsOutput{},
 }
 
 func marshalLinks(links []Link) (s string) {

--- a/core/commands/mount_unix.go
+++ b/core/commands/mount_unix.go
@@ -133,7 +133,7 @@ baz
 		output.IPNS = nsdir
 		return &output, nil
 	},
-	Type: &config.Mounts{},
+	Type: config.Mounts{},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			v := res.Output().(*config.Mounts)

--- a/core/commands/mount_unix.go
+++ b/core/commands/mount_unix.go
@@ -4,6 +4,7 @@ package commands
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -134,11 +135,11 @@ baz
 	},
 	Type: &config.Mounts{},
 	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) ([]byte, error) {
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			v := res.Output().(*config.Mounts)
 			s := fmt.Sprintf("IPFS mounted at: %s\n", v.IPFS)
 			s += fmt.Sprintf("IPNS mounted at: %s\n", v.IPNS)
-			return []byte(s), nil
+			return strings.NewReader(s), nil
 		},
 	},
 }

--- a/core/commands/object.go
+++ b/core/commands/object.go
@@ -108,7 +108,7 @@ multihash.
 			return strings.NewReader(marshalled), nil
 		},
 	},
-	Type: &Object{},
+	Type: Object{},
 }
 
 var objectGetCmd = &cmds.Command{
@@ -162,7 +162,7 @@ This command outputs data in the following encodings:
 
 		return node, nil
 	},
-	Type: &Node{},
+	Type: Node{},
 	Marshalers: cmds.MarshalerMap{
 		cmds.EncodingType("protobuf"): func(res cmds.Response) (io.Reader, error) {
 			node := res.Output().(*Node)
@@ -232,7 +232,7 @@ Data should be in the format specified by <encoding>.
 			return strings.NewReader("added " + object.Hash), nil
 		},
 	},
-	Type: &Object{},
+	Type: Object{},
 }
 
 // objectData takes a key string and writes out the raw bytes of that node (if there is one)

--- a/core/commands/object.go
+++ b/core/commands/object.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+	"strings"
 
 	mh "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
 
@@ -101,10 +102,10 @@ multihash.
 		return objectLinks(n, key)
 	},
 	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) ([]byte, error) {
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			object := res.Output().(*Object)
 			marshalled := marshalLinks(object.Links)
-			return []byte(marshalled), nil
+			return strings.NewReader(marshalled), nil
 		},
 	},
 	Type: &Object{},
@@ -163,13 +164,18 @@ This command outputs data in the following encodings:
 	},
 	Type: &Node{},
 	Marshalers: cmds.MarshalerMap{
-		cmds.EncodingType("protobuf"): func(res cmds.Response) ([]byte, error) {
+		cmds.EncodingType("protobuf"): func(res cmds.Response) (io.Reader, error) {
 			node := res.Output().(*Node)
 			object, err := deserializeNode(node)
 			if err != nil {
 				return nil, err
 			}
-			return object.Marshal()
+
+			marshaled, err := object.Marshal()
+			if err != nil {
+				return nil, err
+			}
+			return bytes.NewReader(marshaled), nil
 		},
 	},
 }
@@ -221,9 +227,9 @@ Data should be in the format specified by <encoding>.
 		return output, nil
 	},
 	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) ([]byte, error) {
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			object := res.Output().(*Object)
-			return []byte("added " + object.Hash), nil
+			return strings.NewReader("added " + object.Hash), nil
 		},
 	},
 	Type: &Object{},

--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -157,7 +157,7 @@ Use --type=<type> to specify the type of pinned keys to list. Valid values are:
 
 		return &KeyList{Keys: keys}, nil
 	},
-	Type: &KeyList{},
+	Type: KeyList{},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: KeyListTextMarshaler,
 	},

--- a/core/commands/publish.go
+++ b/core/commands/publish.go
@@ -86,7 +86,7 @@ Publish a <ref> to another public key:
 			return strings.NewReader(s), nil
 		},
 	},
-	Type: &IpnsEntry{},
+	Type: IpnsEntry{},
 }
 
 func publish(n *core.IpfsNode, k crypto.PrivKey, ref string) (*IpnsEntry, error) {

--- a/core/commands/publish.go
+++ b/core/commands/publish.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"io"
+	"strings"
 
 	cmds "github.com/jbenet/go-ipfs/commands"
 	core "github.com/jbenet/go-ipfs/core"
@@ -78,10 +80,10 @@ Publish a <ref> to another public key:
 		return publish(n, n.PrivateKey, ref)
 	},
 	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) ([]byte, error) {
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			v := res.Output().(*IpnsEntry)
 			s := fmt.Sprintf("Published name %s to %s\n", v.Name, v.Value)
-			return []byte(s), nil
+			return strings.NewReader(s), nil
 		},
 	},
 	Type: &IpnsEntry{},

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -71,7 +71,7 @@ Note: list all refs recursively with -r.
 
 		return getRefs(n, req.Arguments(), unique, recursive)
 	},
-	Type: &KeyList{},
+	Type: KeyList{},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: KeyListTextMarshaler,
 	},

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -1,7 +1,9 @@
 package commands
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 
 	mh "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
 	cmds "github.com/jbenet/go-ipfs/commands"
@@ -16,13 +18,13 @@ type KeyList struct {
 }
 
 // KeyListTextMarshaler outputs a KeyList as plaintext, one key per line
-func KeyListTextMarshaler(res cmds.Response) ([]byte, error) {
+func KeyListTextMarshaler(res cmds.Response) (io.Reader, error) {
 	output := res.Output().(*KeyList)
-	s := ""
+	var buf bytes.Buffer
 	for _, key := range output.Keys {
-		s += key.B58String() + "\n"
+		buf.WriteString(key.B58String() + "\n")
 	}
-	return []byte(s), nil
+	return &buf, nil
 }
 
 var RefsCmd = &cmds.Command{

--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"errors"
+	"io"
+	"strings"
 
 	cmds "github.com/jbenet/go-ipfs/commands"
 )
@@ -71,9 +73,9 @@ Resolve te value of another name:
 		return output, nil
 	},
 	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) ([]byte, error) {
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			output := res.Output().(string)
-			return []byte(output), nil
+			return strings.NewReader(output), nil
 		},
 	},
 }

--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -1,6 +1,9 @@
 package commands
 
 import (
+	"io"
+	"strings"
+
 	cmds "github.com/jbenet/go-ipfs/commands"
 	u "github.com/jbenet/go-ipfs/util"
 )
@@ -90,6 +93,6 @@ type MessageOutput struct {
 	Message string
 }
 
-func MessageTextMarshaler(res cmds.Response) ([]byte, error) {
-	return []byte(res.Output().(*MessageOutput).Message), nil
+func MessageTextMarshaler(res cmds.Response) (io.Reader, error) {
+	return strings.NewReader(res.Output().(*MessageOutput).Message), nil
 }

--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -69,7 +69,7 @@ ipfs swarm peers lists the set of peers this node is connected to.
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: stringListMarshaler,
 	},
-	Type: &stringList{},
+	Type: stringList{},
 }
 
 var swarmConnectCmd = &cmds.Command{
@@ -122,7 +122,7 @@ ipfs swarm connect /ip4/104.131.131.82/tcp/4001/QmaCpDMGvV2BGHeYERUEnRQAwe3N8Szb
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: stringListMarshaler,
 	},
-	Type: &stringList{},
+	Type: stringList{},
 }
 
 func stringListMarshaler(res cmds.Response) (io.Reader, error) {

--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"path"
 
 	cmds "github.com/jbenet/go-ipfs/commands"
@@ -124,7 +125,7 @@ ipfs swarm connect /ip4/104.131.131.82/tcp/4001/QmaCpDMGvV2BGHeYERUEnRQAwe3N8Szb
 	Type: &stringList{},
 }
 
-func stringListMarshaler(res cmds.Response) ([]byte, error) {
+func stringListMarshaler(res cmds.Response) (io.Reader, error) {
 	list, ok := res.Output().(*stringList)
 	if !ok {
 		return nil, errors.New("failed to cast []string")
@@ -132,10 +133,10 @@ func stringListMarshaler(res cmds.Response) ([]byte, error) {
 
 	var buf bytes.Buffer
 	for _, s := range list.Strings {
-		buf.Write([]byte(s))
-		buf.Write([]byte("\n"))
+		buf.WriteString(s)
+		buf.WriteString("\n")
 	}
-	return buf.Bytes(), nil
+	return &buf, nil
 }
 
 // splitAddresses is a function that takes in a slice of string peer addresses

--- a/core/commands/update.go
+++ b/core/commands/update.go
@@ -29,7 +29,7 @@ var UpdateCmd = &cmds.Command{
 		}
 		return updateApply(n)
 	},
-	Type: &UpdateOutput{},
+	Type: UpdateOutput{},
 	Subcommands: map[string]*cmds.Command{
 		"check": UpdateCheckCmd,
 		"log":   UpdateLogCmd,
@@ -62,7 +62,7 @@ var UpdateCheckCmd = &cmds.Command{
 		}
 		return updateCheck(n)
 	},
-	Type: &UpdateOutput{},
+	Type: UpdateOutput{},
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			v := res.Output().(*UpdateOutput)

--- a/core/commands/update.go
+++ b/core/commands/update.go
@@ -1,8 +1,10 @@
 package commands
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 
 	cmds "github.com/jbenet/go-ipfs/commands"
 	"github.com/jbenet/go-ipfs/core"
@@ -33,16 +35,16 @@ var UpdateCmd = &cmds.Command{
 		"log":   UpdateLogCmd,
 	},
 	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) ([]byte, error) {
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			v := res.Output().(*UpdateOutput)
-			s := ""
+			var buf bytes.Buffer
 			if v.NewVersion != v.OldVersion {
-				s = fmt.Sprintf("Successfully updated to IPFS version '%s' (from '%s')\n",
-					v.NewVersion, v.OldVersion)
+				buf.WriteString(fmt.Sprintf("Successfully updated to IPFS version '%s' (from '%s')\n",
+					v.NewVersion, v.OldVersion))
 			} else {
-				s = fmt.Sprintf("Already updated to latest version ('%s')\n", v.NewVersion)
+				buf.WriteString(fmt.Sprintf("Already updated to latest version ('%s')\n", v.NewVersion))
 			}
-			return []byte(s), nil
+			return &buf, nil
 		},
 	},
 }
@@ -62,16 +64,16 @@ var UpdateCheckCmd = &cmds.Command{
 	},
 	Type: &UpdateOutput{},
 	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) ([]byte, error) {
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			v := res.Output().(*UpdateOutput)
-			s := ""
+			var buf bytes.Buffer
 			if v.NewVersion != v.OldVersion {
-				s = fmt.Sprintf("A new version of IPFS is available ('%s', currently running '%s')\n",
-					v.NewVersion, v.OldVersion)
+				buf.WriteString(fmt.Sprintf("A new version of IPFS is available ('%s', currently running '%s')\n",
+					v.NewVersion, v.OldVersion))
 			} else {
-				s = fmt.Sprintf("Already updated to latest version ('%s')\n", v.NewVersion)
+				buf.WriteString(fmt.Sprintf("Already updated to latest version ('%s')\n", v.NewVersion))
 			}
-			return []byte(s), nil
+			return &buf, nil
 		},
 	},
 }

--- a/core/commands/version.go
+++ b/core/commands/version.go
@@ -41,5 +41,5 @@ var VersionCmd = &cmds.Command{
 			return strings.NewReader(fmt.Sprintf("ipfs version %s\n", v.Version)), nil
 		},
 	},
-	Type: &VersionOutput{},
+	Type: VersionOutput{},
 }

--- a/core/commands/version.go
+++ b/core/commands/version.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"fmt"
+	"io"
+	"strings"
 
 	cmds "github.com/jbenet/go-ipfs/commands"
 	config "github.com/jbenet/go-ipfs/config"
@@ -26,7 +28,7 @@ var VersionCmd = &cmds.Command{
 		}, nil
 	},
 	Marshalers: cmds.MarshalerMap{
-		cmds.Text: func(res cmds.Response) ([]byte, error) {
+		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			v := res.Output().(*VersionOutput)
 
 			number, found, err := res.Request().Option("number").Bool()
@@ -34,9 +36,9 @@ var VersionCmd = &cmds.Command{
 				return nil, err
 			}
 			if found && number {
-				return []byte(fmt.Sprintln(v.Version)), nil
+				return strings.NewReader(fmt.Sprintln(v.Version)), nil
 			}
-			return []byte(fmt.Sprintf("ipfs version %s\n", v.Version)), nil
+			return strings.NewReader(fmt.Sprintf("ipfs version %s\n", v.Version)), nil
 		},
 	},
 	Type: &VersionOutput{},


### PR DESCRIPTION
This PR lets commands return channels, which allows for streaming object output. Now the add command will show hashes of files as they are added. :smile:

It's pretty satisfying to watch it add the whole go-ipfs directory.

Thanks to the sharness tests for catching various edge-case bugs I wouldn't have noticed. :+1: