### PR TITLE
Fix test_docker Makefile target and rename it test_3node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ test_short: build test_go_short test_sharness_short
 
 test_expensive: build test_go_expensive test_sharness_expensive
 
-test_docker:
-	cd dockertest/ && make
+test_3node:
+	cd test/3nodetest && make
 
 test_go_short:
 	go test -test.short ./...


### PR DESCRIPTION
The dockertest/ directory has been moved into test/ and
it has been renamed 3nodetest/ in commit 28cf220d
(dockertest -> test/3nodetest).

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>