### PR TITLE
Assert output types

### DIFF
--- a/core/commands/object.go
+++ b/core/commands/object.go
@@ -219,7 +219,7 @@ var objectStatCmd = &cmds.Command{
 			return nil, err
 		}
 
-		return ns, nil
+		return &ns, nil
 	},
 	Type: dag.NodeStat{},
 	Marshalers: cmds.MarshalerMap{


### PR DESCRIPTION
This fixes a bug in `object stat` that causes it to error when run locally (not on the daemon). This is because commands must return pointer values (sadly there's no way around it with our crazy `interface{}` magic in the commands package).

I added a check for this that will panic if a developer makes their command return a non-pointer to prevent the mistake from happening in the future.