### PR TITLE
install-sharness.sh: use git instead of wget and shasum

### DIFF
--- a/test/sharness/lib/install-sharness.sh
+++ b/test/sharness/lib/install-sharness.sh
@@ -7,53 +7,20 @@
 
 # settings
 version=50229a79ba22b2f13ccd82451d86570fecbd194c
-urlprefix=https://raw.githubusercontent.com/mlafeldt/sharness/$version
-installpath=lib/sharness
-
-# files to download
-sfile=sharness.sh
-shash=eeaf96630fc25ec58fb678b64ef9772d5eb92f64
-
-afile=aggregate-results.sh
-ahash=948d6bc03222c5c00a1ed048068508d5ea1cce59
+urlprefix=https://github.com/mlafeldt/sharness.git
+clonedir=lib
+sharnessdir=sharness
 
 die() {
-  echo >&2 $@
+  echo >&2 "$@"
   exit 1
 }
 
-verified_download() {
-  file=$1
-  hash1=$2
-  url=$urlprefix/$file
+mkdir -p "$clonedir" || die "Could not create '$clonedir' directory"
+cd "$clonedir" || die "Could not cd into '$clonedir' directory"
 
-  # download it
-  wget -q $url -O $file.test
+git clone "$urlprefix" || die "Could not clone '$urlprefix'"
+cd "$sharnessdir" || die "Could not cd into '$sharnessdir' directory"
+git checkout "$version" || die "Could not checkout '$version'"
 
-  # verify it's the right file
-  hash2=`cat $file.test | shasum | cut -c1-40`
-  if test "$hash1" != "$hash2"; then
-    echo "$file verification failed:"
-    echo "  $hash1 != $hash2"
-    return -1
-  fi
-  return 0
-}
-
-mkdir -p $installpath || die "Could not create 'sharness' directory"
-cd $installpath || die "Could not cd into 'sharness' directory"
-
-verified_download "$sfile" "$shash"; sok=$?
-verified_download "$afile" "$ahash"; aok=$?
-if test "$sok" != 0 || test "$aok" != 0; then
-  rm $afile.test
-  rm $sfile.test
-  exit -1
-fi
-
-# ok, move things into place
-mv $sfile.test $sfile
-mv $afile.test $afile
-chmod +x $sfile
-chmod +x $afile
 exit 0


### PR DESCRIPTION
This is the first step to address issue #500 (Start using `multihash` tool instead of `shasum`)

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>