### PR TITLE
benchmark Sign and Verify operations

### DIFF
--- a/p2p/crypto/bench_test.go
+++ b/p2p/crypto/bench_test.go
@@ -1,0 +1,54 @@
+package crypto
+
+import "testing"
+
+func BenchmarkSign1B(b *testing.B)      { RunBenchmarkSign(b, 1) }
+func BenchmarkSign10B(b *testing.B)     { RunBenchmarkSign(b, 10) }
+func BenchmarkSign100B(b *testing.B)    { RunBenchmarkSign(b, 100) }
+func BenchmarkSign1000B(b *testing.B)   { RunBenchmarkSign(b, 1000) }
+func BenchmarkSign10000B(b *testing.B)  { RunBenchmarkSign(b, 10000) }
+func BenchmarkSign100000B(b *testing.B) { RunBenchmarkSign(b, 100000) }
+
+func BenchmarkVerify1B(b *testing.B)      { RunBenchmarkVerify(b, 1) }
+func BenchmarkVerify10B(b *testing.B)     { RunBenchmarkVerify(b, 10) }
+func BenchmarkVerify100B(b *testing.B)    { RunBenchmarkVerify(b, 100) }
+func BenchmarkVerify1000B(b *testing.B)   { RunBenchmarkVerify(b, 1000) }
+func BenchmarkVerify10000B(b *testing.B)  { RunBenchmarkVerify(b, 10000) }
+func BenchmarkVerify100000B(b *testing.B) { RunBenchmarkVerify(b, 100000) }
+
+func RunBenchmarkSign(b *testing.B, numBytes int) {
+	secret, _, err := GenerateKeyPair(RSA, 1024)
+	if err != nil {
+		b.Fatal(err)
+	}
+	someData := make([]byte, numBytes)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := secret.Sign(someData)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func RunBenchmarkVerify(b *testing.B, numBytes int) {
+	secret, public, err := GenerateKeyPair(RSA, 1024)
+	if err != nil {
+		b.Fatal(err)
+	}
+	someData := make([]byte, numBytes)
+	signature, err := secret.Sign(someData)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		valid, err := public.Verify(someData, signature)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if !valid {
+			b.Fatal("signature should be valid")
+		}
+	}
+}


### PR DESCRIPTION
#525 proposes signatures for DHT `Provides` records. Wanted to make sure that the runtime cost is well understood and that feasibility can be evaluated based on empirical evidence.

```
BenchmarkSign1B             1000           2406924 ns/op
BenchmarkSign10B            1000           2360527 ns/op
BenchmarkSign100B           1000           2354136 ns/op
BenchmarkSign1000B           500           2361775 ns/op
BenchmarkSign10000B          500           2415993 ns/op
BenchmarkSign100000B         500           2718051 ns/op
BenchmarkVerify1B          30000             52117 ns/op
BenchmarkVerify10B         30000             50968 ns/op
BenchmarkVerify100B        30000             51037 ns/op
BenchmarkVerify1000B       30000             56768 ns/op
BenchmarkVerify10000B      10000            105744 ns/op
BenchmarkVerify100000B      2000            628530 ns/op
```