### PR TITLE
use conns to enumerate peers for network diagnostic

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -144,7 +144,7 @@
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-peerstream",
-			"Rev": "cddf450fca891e45aa471d882dae2c28ac642fb4"
+			"Rev": "ccc044c2a5999f36743881ff73568660a581f2f2"
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-random",

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/conn.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/conn.go
@@ -2,6 +2,7 @@ package peerstream
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"sync"
 
@@ -53,6 +54,15 @@ func newConn(nconn net.Conn, tconn pst.Conn, s *Swarm) *Conn {
 		groups:  groupSet{m: make(map[Group]struct{})},
 		streams: make(map[*Stream]struct{}),
 	}
+}
+
+// String returns a string representation of the Conn
+func (c *Conn) String() string {
+	c.streamLock.RLock()
+	ls := len(c.streams)
+	c.streamLock.RUnlock()
+	f := "<peerstream.Conn %d streams %s <--> %s>"
+	return fmt.Sprintf(f, ls, c.netConn.LocalAddr(), c.netConn.RemoteAddr())
 }
 
 // Swarm returns the Swarm associated with this Conn

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/listener.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/listener.go
@@ -24,6 +24,12 @@ func newListener(nl net.Listener, s *Swarm) *Listener {
 	}
 }
 
+// String returns a string representation of the Listener
+func (l *Listener) String() string {
+	f := "<peerstream.Listener %s>"
+	return fmt.Sprintf(f, l.netList.Addr())
+}
+
 // NetListener is the underlying net.Listener
 func (l *Listener) NetListener() net.Listener {
 	return l.netList

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/stream.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/stream.go
@@ -1,6 +1,8 @@
 package peerstream
 
 import (
+	"fmt"
+
 	pst "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport"
 )
 
@@ -29,6 +31,12 @@ func newStream(ss pst.Stream, c *Conn) *Stream {
 	}
 	s.groups.AddSet(&c.groups) // inherit groups
 	return s
+}
+
+// String returns a string representation of the Stream
+func (s *Stream) String() string {
+	f := "<peerstream.Stream %s <--> %s>"
+	return fmt.Sprintf(f, s.conn.NetConn().LocalAddr(), s.conn.NetConn().RemoteAddr())
 }
 
 // SPDYStream returns the underlying *spdystream.Stream

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/swarm.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/swarm.go
@@ -2,6 +2,7 @@ package peerstream
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"sync"
 	"time"
@@ -54,6 +55,49 @@ func NewSwarm(t pst.Transport) *Swarm {
 	}
 	go s.connGarbageCollect()
 	return s
+}
+
+// String returns a string with various internal stats
+func (s *Swarm) String() string {
+	s.listenerLock.Lock()
+	ls := len(s.listeners)
+	s.listenerLock.Unlock()
+
+	s.connLock.Lock()
+	cs := len(s.conns)
+	s.connLock.Unlock()
+
+	s.streamLock.Lock()
+	ss := len(s.streams)
+	s.streamLock.Unlock()
+
+	str := "<peerstream.Swarm %d listeners %d conns %d streams>"
+	return fmt.Sprintf(str, ls, cs, ss)
+}
+
+// Dump returns a string with all the internal state
+func (s *Swarm) Dump() string {
+	str := s.String() + "\n"
+
+	s.listenerLock.Lock()
+	for l, _ := range s.listeners {
+		str += fmt.Sprintf("\t%s %v\n", l, l.Groups())
+	}
+	s.listenerLock.Unlock()
+
+	s.connLock.Lock()
+	for c, _ := range s.conns {
+		str += fmt.Sprintf("\t%s %v\n", c, c.Groups())
+	}
+	s.connLock.Unlock()
+
+	s.streamLock.Lock()
+	for ss, _ := range s.streams {
+		str += fmt.Sprintf("\t%s %v\n", ss, ss.Groups())
+	}
+	s.streamLock.Unlock()
+
+	return str
 }
 
 // SetStreamHandler assigns the stream handler in the swarm.

--- a/core/commands/diag.go
+++ b/core/commands/diag.go
@@ -14,6 +14,7 @@ type DiagnosticConnection struct {
 	ID string
 	// TODO use milliseconds or microseconds for human readability
 	NanosecondsLatency uint64
+	Count              int
 }
 
 type DiagnosticPeer struct {
@@ -70,6 +71,7 @@ connected peers and latencies between them.
 				connections[j] = DiagnosticConnection{
 					ID:                 conn.ID,
 					NanosecondsLatency: uint64(conn.Latency.Nanoseconds()),
+					Count:              conn.Count,
 				}
 			}
 
@@ -102,16 +104,10 @@ connected peers and latencies between them.
 }
 
 func printDiagnostics(out io.Writer, info *DiagnosticOutput) error {
-
 	diagTmpl := `
 {{ range $peer := .Peers }}
-ID {{ $peer.ID }}
-	up {{ $peer.UptimeSeconds }} seconds
-	connected to {{ len .Connections }}...
-		{{ range $connection := .Connections }}
-		ID {{ $connection.ID }}
-		latency: {{ $connection.NanosecondsLatency }} ns
-		{{ end }}
+ID {{ $peer.ID }} up {{ $peer.UptimeSeconds }} seconds connected to {{ len .Connections }}:{{ range $connection := .Connections }}
+	ID {{ $connection.ID }} connections: {{ $connection.Count }} latency: {{ $connection.NanosecondsLatency }} ns{{ end }}
 {{end}}
 `
 

--- a/diagnostics/diag.go
+++ b/diagnostics/diag.go
@@ -98,7 +98,13 @@ func (di *DiagInfo) Marshal() []byte {
 }
 
 func (d *Diagnostics) getPeers() []peer.ID {
-	return d.host.Network().Peers()
+	conns := d.host.Network().Conns()
+	peers := make([]peer.ID, len(conns))
+
+	for i, c := range conns {
+		peers[i] = c.RemotePeer()
+	}
+	return peers
 }
 
 func (d *Diagnostics) getDiagInfo() *DiagInfo {

--- a/diagnostics/diag.go
+++ b/diagnostics/diag.go
@@ -99,13 +99,13 @@ func (di *DiagInfo) Marshal() []byte {
 
 func (d *Diagnostics) getPeers() []peer.ID {
 	peers := d.host.Network().Peers()
-	pmap := make(map[peer.ID]struct{})
+	seen := make(map[peer.ID]struct{})
 	out := make([]peer.ID, 0, len(peers))
 	for _, p := range peers {
-		_, ok := pmap[p]
+		_, ok := seen[p]
 		if !ok {
 			out = append(out, p)
-			pmap[p] = struct{}{}
+			seen[p] = struct{}{}
 		}
 	}
 

--- a/diagnostics/diag.go
+++ b/diagnostics/diag.go
@@ -60,6 +60,7 @@ func NewDiagnostics(self peer.ID, h host.Host) *Diagnostics {
 type connDiagInfo struct {
 	Latency time.Duration
 	ID      string
+	Count   int
 }
 
 type DiagInfo struct {
@@ -97,19 +98,13 @@ func (di *DiagInfo) Marshal() []byte {
 	return b
 }
 
-func (d *Diagnostics) getPeers() []peer.ID {
-	peers := d.host.Network().Peers()
-	seen := make(map[peer.ID]struct{})
-	out := make([]peer.ID, 0, len(peers))
-	for _, p := range peers {
-		_, ok := seen[p]
-		if !ok {
-			out = append(out, p)
-			seen[p] = struct{}{}
-		}
+func (d *Diagnostics) getPeers() map[peer.ID]int {
+	counts := make(map[peer.ID]int)
+	for _, p := range d.host.Network().Peers() {
+		counts[p]++
 	}
 
-	return out
+	return counts
 }
 
 func (d *Diagnostics) getDiagInfo() *DiagInfo {
@@ -121,8 +116,12 @@ func (d *Diagnostics) getDiagInfo() *DiagInfo {
 
 	// di.BwIn, di.BwOut = d.host.BandwidthTotals() //TODO fix this.
 
-	for _, p := range d.getPeers() {
-		d := connDiagInfo{d.host.Peerstore().LatencyEWMA(p), p.Pretty()}
+	for p, n := range d.getPeers() {
+		d := connDiagInfo{
+			Latency: d.host.Peerstore().LatencyEWMA(p),
+			ID:      p.Pretty(),
+			Count:   n,
+		}
 		di.Connections = append(di.Connections, d)
 	}
 	return di
@@ -157,7 +156,7 @@ func (d *Diagnostics) GetDiagnostic(timeout time.Duration) ([]*DiagInfo, error) 
 
 	respdata := make(chan []byte)
 	sends := 0
-	for _, p := range peers {
+	for p, _ := range peers {
 		log.Debugf("Sending getDiagnostic to: %s", p)
 		sends++
 		go func(p peer.ID) {
@@ -265,7 +264,7 @@ func (d *Diagnostics) handleDiagnostic(p peer.ID, pmes *pb.Message) (*pb.Message
 
 	respdata := make(chan []byte)
 	sendcount := 0
-	for _, p := range d.getPeers() {
+	for p, _ := range d.getPeers() {
 		log.Debugf("Sending diagnostic request to peer: %s", p)
 		sendcount++
 		go func(p peer.ID) {

--- a/p2p/net/swarm/peers_test.go
+++ b/p2p/net/swarm/peers_test.go
@@ -1,0 +1,72 @@
+package swarm
+
+import (
+	"testing"
+
+	peer "github.com/jbenet/go-ipfs/p2p/peer"
+
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
+	ma "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
+)
+
+func TestPeers(t *testing.T) {
+	// t.Skip("skipping for another test")
+
+	ctx := context.Background()
+	swarms := makeSwarms(ctx, t, 2)
+	s1 := swarms[0]
+	s2 := swarms[1]
+
+	connect := func(s *Swarm, dst peer.ID, addr ma.Multiaddr) {
+		// TODO: make a DialAddr func.
+		s.peers.AddAddress(dst, addr)
+		// t.Logf("connections from %s", s.LocalPeer())
+		// for _, c := range s.ConnectionsToPeer(dst) {
+		// 	t.Logf("connection from %s to %s: %v", s.LocalPeer(), dst, c)
+		// }
+		// t.Logf("")
+		if _, err := s.Dial(ctx, dst); err != nil {
+			t.Fatal("error swarm dialing to peer", err)
+		}
+		// t.Log(s.swarm.Dump())
+	}
+
+	s1GotConn := make(chan struct{}, 0)
+	s2GotConn := make(chan struct{}, 0)
+	s1.SetConnHandler(func(c *Conn) {
+		s1GotConn <- struct{}{}
+	})
+	s2.SetConnHandler(func(c *Conn) {
+		s2GotConn <- struct{}{}
+	})
+
+	connect(s1, s2.LocalPeer(), s2.ListenAddresses()[0])
+	<-s2GotConn // have to wait here so the other side catches up.
+	connect(s2, s1.LocalPeer(), s1.ListenAddresses()[0])
+
+	for i := 0; i < 100; i++ {
+		connect(s1, s2.LocalPeer(), s2.ListenAddresses()[0])
+		connect(s2, s1.LocalPeer(), s1.ListenAddresses()[0])
+	}
+
+	for _, s := range swarms {
+		log.Infof("%s swarm routing table: %s", s.local, s.Peers())
+	}
+
+	test := func(s *Swarm) {
+		expect := 1
+		actual := len(s.Peers())
+		if actual != expect {
+			t.Errorf("%s has %d peers, not %d: %v", s.LocalPeer(), actual, expect, s.Peers())
+			t.Log(s.swarm.Dump())
+		}
+		actual = len(s.Connections())
+		if actual != expect {
+			t.Errorf("%s has %d conns, not %d: %v", s.LocalPeer(), actual, expect, s.Connections())
+			t.Log(s.swarm.Dump())
+		}
+	}
+
+	test(s1)
+	test(s2)
+}

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -150,6 +150,7 @@ func (s *Swarm) Peers() []peer.ID {
 			continue
 		}
 
+		seen[p] = struct{}{}
 		peers = append(peers, p)
 	}
 	return peers


### PR DESCRIPTION
Using `Network().Peers()` led to some incorrect things. Namely, duplicate peers showing up in the listing like:

```
ID QmUqfiKyst7x9rUCjpLr9DF45Z1e6SQE2Z8yX8otfnQ4kS
	up 432 seconds
	connected to 9...
		
		ID Qmd71aoXHswYuKUsvFSWhxx4Yh4RnEaaFguWtr2oCVBJkc
		latency: 172186183 ns
		
		ID QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
		latency: 356768419 ns
		
		ID QmSoLpPVmHKQ4XTPdz8tjDFgdeRFkpV8JgYq8JVJ69RrZm
		latency: 211111688 ns
		
		ID QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z
		latency: 237909867 ns
		
		ID QmUqfiKyst7x9rUCjpLr9DF45Z1e6SQE2Z8yX8otfnQ4kS
		latency: 0 ns
		
		ID QmUqfiKyst7x9rUCjpLr9DF45Z1e6SQE2Z8yX8otfnQ4kS
		latency: 0 ns
		
		ID QmUqfiKyst7x9rUCjpLr9DF45Z1e6SQE2Z8yX8otfnQ4kS
		latency: 0 ns
		
		ID QmUqfiKyst7x9rUCjpLr9DF45Z1e6SQE2Z8yX8otfnQ4kS
		latency: 0 ns
		
		ID QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm
		latency: 227224936 ns
```
