### PR TITLE
ds-query + ipfs refs local

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -156,7 +156,7 @@
 		},
 		{
 			"ImportPath": "github.com/jbenet/goprocess",
-			"Rev": "162148a58668ca38b0b8f0459ccc6ca88e32f1f4"
+			"Rev": "7f96033e206c3cd4e79d1c61cbdfff57869feaf8"
 		},
 		{
 			"ImportPath": "github.com/kr/binarydist",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -110,7 +110,7 @@
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-datastore",
-			"Rev": "6a1c83bda2a71a9bdc936749fdb507df958ed949"
+			"Rev": "8a8988d1a4e174274bd4a9dd55c4837f46fdf323"
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-fuse-version",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -110,7 +110,7 @@
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-datastore",
-			"Rev": "8a8988d1a4e174274bd4a9dd55c4837f46fdf323"
+			"Rev": "35738aceb35505bd3c77c2a618fb1947ca3f72da"
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-fuse-version",

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/.travis.yml
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+
+go:
+  - 1.3
+  - release
+  - tip
+
+script:
+  - make test
+
+env: TEST_NO_FUSE=1 TEST_VERBOSE=1

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/Godeps/Godeps.json
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/Godeps/Godeps.json
@@ -19,6 +19,10 @@
 			"Rev": "4dfff096c4973178c8f35cf6dd1a732a0a139370"
 		},
 		{
+			"ImportPath": "github.com/jbenet/goprocess",
+			"Rev": "b4b4178efcf2404ce9db72438c9c49db2fb399d8"
+		},
+		{
 			"ImportPath": "github.com/mattbaird/elastigo/api",
 			"Rev": "041b88c1fcf6489a5721ede24378ce1253b9159d"
 		},

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/Makefile
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/Makefile
@@ -1,6 +1,9 @@
 build:
 	go build
 
+test:
+	go test ./...
+
 # saves/vendors third-party dependencies to Godeps/_workspace
 # -r flag rewrites import paths to use the vendored path
 # ./... performs operation on all packages in tree

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/basic_ds.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/basic_ds.go
@@ -1,6 +1,10 @@
 package datastore
 
-import "log"
+import (
+	"log"
+
+	query "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
+)
 
 // Here are some basic datastore implementations.
 
@@ -45,13 +49,15 @@ func (d *MapDatastore) Delete(key Key) (err error) {
 	return nil
 }
 
-// KeyList implements Datastore.KeyList
-func (d *MapDatastore) KeyList() ([]Key, error) {
-	var keys []Key
-	for k := range d.values {
-		keys = append(keys, k)
+// Query implements Datastore.Query
+func (d *MapDatastore) Query(q query.Query) (*query.Results, error) {
+	re := make([]query.Entry, 0, len(d.values))
+	for k, v := range d.values {
+		re = append(re, query.Entry{Key: k.String(), Value: v})
 	}
-	return keys, nil
+	r := query.ResultsWithEntries(q, re)
+	r = q.ApplyTo(r)
+	return r, nil
 }
 
 // NullDatastore stores nothing, but conforms to the API.
@@ -84,9 +90,9 @@ func (d *NullDatastore) Delete(key Key) (err error) {
 	return nil
 }
 
-// KeyList implements Datastore.KeyList
-func (d *NullDatastore) KeyList() ([]Key, error) {
-	return nil, nil
+// Query implements Datastore.Query
+func (d *NullDatastore) Query(q query.Query) (*query.Results, error) {
+	return query.ResultsWithEntries(q, nil), nil
 }
 
 // LogDatastore logs all accesses through the datastore.
@@ -140,8 +146,8 @@ func (d *LogDatastore) Delete(key Key) (err error) {
 	return d.child.Delete(key)
 }
 
-// KeyList implements Datastore.KeyList
-func (d *LogDatastore) KeyList() ([]Key, error) {
-	log.Printf("%s: Get KeyList\n", d.Name)
-	return d.child.KeyList()
+// Query implements Datastore.Query
+func (d *LogDatastore) Query(q query.Query) (*query.Results, error) {
+	log.Printf("%s: Query\n", d.Name)
+	return d.child.Query(q)
 }

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/basic_ds.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/basic_ds.go
@@ -3,7 +3,7 @@ package datastore
 import (
 	"log"
 
-	query "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
+	dsq "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
 )
 
 // Here are some basic datastore implementations.
@@ -50,13 +50,13 @@ func (d *MapDatastore) Delete(key Key) (err error) {
 }
 
 // Query implements Datastore.Query
-func (d *MapDatastore) Query(q query.Query) (*query.Results, error) {
-	re := make([]query.Entry, 0, len(d.values))
+func (d *MapDatastore) Query(q dsq.Query) (dsq.Results, error) {
+	re := make([]dsq.Entry, 0, len(d.values))
 	for k, v := range d.values {
-		re = append(re, query.Entry{Key: k.String(), Value: v})
+		re = append(re, dsq.Entry{Key: k.String(), Value: v})
 	}
-	r := query.ResultsWithEntries(q, re)
-	r = q.ApplyTo(r)
+	r := dsq.ResultsWithEntries(q, re)
+	r = dsq.NaiveQueryApply(q, r)
 	return r, nil
 }
 
@@ -91,8 +91,8 @@ func (d *NullDatastore) Delete(key Key) (err error) {
 }
 
 // Query implements Datastore.Query
-func (d *NullDatastore) Query(q query.Query) (*query.Results, error) {
-	return query.ResultsWithEntries(q, nil), nil
+func (d *NullDatastore) Query(q dsq.Query) (dsq.Results, error) {
+	return dsq.ResultsWithEntries(q, nil), nil
 }
 
 // LogDatastore logs all accesses through the datastore.
@@ -147,7 +147,7 @@ func (d *LogDatastore) Delete(key Key) (err error) {
 }
 
 // Query implements Datastore.Query
-func (d *LogDatastore) Query(q query.Query) (*query.Results, error) {
+func (d *LogDatastore) Query(q dsq.Query) (dsq.Results, error) {
 	log.Printf("%s: Query\n", d.Name)
 	return d.child.Query(q)
 }

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/datastore.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/datastore.go
@@ -2,6 +2,8 @@ package datastore
 
 import (
 	"errors"
+
+	query "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
 )
 
 /*
@@ -52,8 +54,19 @@ type Datastore interface {
 	// Delete removes the value for given `key`.
 	Delete(key Key) (err error)
 
-	// KeyList returns a list of keys in the datastore
-	KeyList() ([]Key, error)
+	// Query searches the datastore and returns a query result. This function
+	// may return before the query actually runs. To wait for the query:
+	//
+	//   result, _ := ds.Query(q)
+	//
+	//   // use the channel interface; result may come in at different times
+	//   for entry := range result.Entries() { ... }
+	//
+	//	 // or wait for the query to be completely done
+	//   result.Wait()
+	//   result.AllEntries()
+	//
+	Query(q query.Query) (*query.Results, error)
 }
 
 // ThreadSafeDatastore is an interface that all threadsafe datastore should

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/datastore.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/datastore.go
@@ -66,7 +66,7 @@ type Datastore interface {
 	//   result.Wait()
 	//   result.AllEntries()
 	//
-	Query(q query.Query) (*query.Results, error)
+	Query(q query.Query) (query.Results, error)
 }
 
 // ThreadSafeDatastore is an interface that all threadsafe datastore should

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/elastigo/datastore.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/elastigo/datastore.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/codahale/blake2"
 	ds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
+	query "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
 	"github.com/mattbaird/elastigo/api"
 	"github.com/mattbaird/elastigo/core"
 )
@@ -112,7 +113,7 @@ func (d *Datastore) Delete(key ds.Key) (err error) {
 	return nil
 }
 
-func (d *Datastore) KeyList() ([]ds.Key, error) {
+func (d *Datastore) Query(query.Query) (*query.Results, error) {
 	return nil, errors.New("Not yet implemented!")
 }
 

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/elastigo/datastore.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/elastigo/datastore.go
@@ -113,7 +113,7 @@ func (d *Datastore) Delete(key ds.Key) (err error) {
 	return nil
 }
 
-func (d *Datastore) Query(query.Query) (*query.Results, error) {
+func (d *Datastore) Query(query.Query) (query.Results, error) {
 	return nil, errors.New("Not yet implemented!")
 }
 

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/fs/fs.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/fs/fs.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 
 	ds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
+	query "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
 )
+
+var ObjectKeySuffix = ".dsobject"
 
 // Datastore uses a standard Go map for internal storage.
 type Datastore struct {
@@ -26,7 +29,7 @@ func NewDatastore(path string) (ds.Datastore, error) {
 
 // KeyFilename returns the filename associated with `key`
 func (d *Datastore) KeyFilename(key ds.Key) string {
-	return filepath.Join(d.path, key.String(), ".dsobject")
+	return filepath.Join(d.path, key.String(), ObjectKeySuffix)
 }
 
 // Put stores the given value.
@@ -79,10 +82,10 @@ func (d *Datastore) Delete(key ds.Key) (err error) {
 	return os.Remove(fn)
 }
 
-// KeyList returns a list of all keys in the datastore
-func (d *Datastore) KeyList() ([]ds.Key, error) {
+// Query implements Datastore.Query
+func (d *Datastore) Query(q query.Query) (*query.Results, error) {
 
-	keys := []ds.Key{}
+	entries := make(chan query.Entry)
 
 	walkFn := func(path string, info os.FileInfo, err error) error {
 		// remove ds path prefix
@@ -91,14 +94,22 @@ func (d *Datastore) KeyList() ([]ds.Key, error) {
 		}
 
 		if !info.IsDir() {
+			if strings.HasSuffix(path, ObjectKeySuffix) {
+				path = path[:len(path)-len(ObjectKeySuffix)]
+			}
 			key := ds.NewKey(path)
-			keys = append(keys, key)
+			entries <- query.Entry{Key: key.String(), Value: query.NotFetched}
 		}
 		return nil
 	}
 
-	filepath.Walk(d.path, walkFn)
-	return keys, nil
+	go func() {
+		filepath.Walk(d.path, walkFn)
+		close(entries)
+	}()
+	r := query.ResultsWithEntriesChan(q, entries)
+	r = q.ApplyTo(r)
+	return r, nil
 }
 
 // isDir returns whether given path is a directory

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/fs/fs_test.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/fs/fs_test.go
@@ -67,7 +67,10 @@ func (ks *DSSuite) TestBasic(c *C) {
 		"/foo/bar/bazb",
 		"/foo/bar/baz/barb",
 	}
-	all := r.AllEntries()
+	all, err := r.Rest()
+	if err != nil {
+		c.Fatal(err)
+	}
 	c.Check(len(all), Equals, len(expect))
 
 	for _, k := range expect {

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/fs/fs_test.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/fs/fs_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"testing"
 
+	. "launchpad.net/gocheck"
+
 	ds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	fs "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/fs"
-	. "launchpad.net/gocheck"
+	query "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -53,6 +55,32 @@ func (ks *DSSuite) TestBasic(c *C) {
 		v, err := ks.ds.Get(k)
 		c.Check(err, Equals, nil)
 		c.Check(bytes.Equal(v.([]byte), []byte(k.String())), Equals, true)
+	}
+
+	r, err := ks.ds.Query(query.Query{Prefix: "/foo/bar/"})
+	if err != nil {
+		c.Check(err, Equals, nil)
+	}
+
+	expect := []string{
+		"/foo/bar/baz",
+		"/foo/bar/bazb",
+		"/foo/bar/baz/barb",
+	}
+	all := r.AllEntries()
+	c.Check(len(all), Equals, len(expect))
+
+	for _, k := range expect {
+		found := false
+		for _, e := range all {
+			if e.Key == k {
+				found = true
+			}
+		}
+
+		if !found {
+			c.Error("did not find expected key: ", k)
+		}
 	}
 }
 

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/key.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/key.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go-uuid/uuid"
+
+	dsq "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
 )
 
 /*
@@ -239,3 +241,12 @@ type KeySlice []Key
 func (p KeySlice) Len() int           { return len(p) }
 func (p KeySlice) Less(i, j int) bool { return p[i].Less(p[j]) }
 func (p KeySlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+// EntryKeys
+func EntryKeys(e []dsq.Entry) []Key {
+	ks := make([]Key, len(e))
+	for i, e := range e {
+		ks[i] = NewKey(e.Key)
+	}
+	return ks
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/keytransform/keytransform.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/keytransform/keytransform.go
@@ -52,24 +52,24 @@ func (d *ktds) Delete(key ds.Key) (err error) {
 }
 
 // Query implements Query, inverting keys on the way back out.
-func (d *ktds) Query(q dsq.Query) (*dsq.Results, error) {
-
-	q2 := q
-	q2.Prefix = d.ConvertKey(ds.NewKey(q2.Prefix)).String()
-	r, err := d.child.Query(q2)
+func (d *ktds) Query(q dsq.Query) (dsq.Results, error) {
+	qr, err := d.child.Query(q)
 	if err != nil {
 		return nil, err
 	}
 
-	ch := make(chan dsq.Entry)
+	ch := make(chan dsq.Result)
 	go func() {
-		for e := range r.Entries() {
-			e.Key = d.InvertKey(ds.NewKey(e.Key)).String()
-			ch <- e
+		defer close(ch)
+		defer qr.Close()
+
+		for r := range qr.Next() {
+			if r.Error == nil {
+				r.Entry.Key = d.InvertKey(ds.NewKey(r.Entry.Key)).String()
+			}
+			ch <- r
 		}
-		close(ch)
 	}()
 
-	r2 := dsq.ResultsWithEntriesChan(q, ch)
-	return r2, nil
+	return dsq.DerivedResults(qr, ch), nil
 }

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/keytransform/keytransform_test.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/keytransform/keytransform_test.go
@@ -5,9 +5,11 @@ import (
 	"sort"
 	"testing"
 
+	. "launchpad.net/gocheck"
+
 	ds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	kt "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/keytransform"
-	. "launchpad.net/gocheck"
+	dsq "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -60,10 +62,13 @@ func (ks *DSSuite) TestBasic(c *C) {
 		c.Check(bytes.Equal(v2.([]byte), []byte(k.String())), Equals, true)
 	}
 
-	listA, errA := mpds.KeyList()
-	listB, errB := ktds.KeyList()
+	listAr, errA := mpds.Query(dsq.Query{})
+	listBr, errB := ktds.Query(dsq.Query{})
 	c.Check(errA, Equals, nil)
 	c.Check(errB, Equals, nil)
+
+	listA := ds.EntryKeys(listAr.AllEntries())
+	listB := ds.EntryKeys(listBr.AllEntries())
 	c.Check(len(listA), Equals, len(listB))
 
 	// sort them cause yeah.
@@ -75,6 +80,9 @@ func (ks *DSSuite) TestBasic(c *C) {
 		c.Check(pair.Invert(kA), Equals, kB)
 		c.Check(kA, Equals, pair.Convert(kB))
 	}
+
+	c.Log("listA: ", listA)
+	c.Log("listB: ", listB)
 }
 
 func strsToKeys(strs []string) []ds.Key {

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/keytransform/keytransform_test.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/keytransform/keytransform_test.go
@@ -62,13 +62,18 @@ func (ks *DSSuite) TestBasic(c *C) {
 		c.Check(bytes.Equal(v2.([]byte), []byte(k.String())), Equals, true)
 	}
 
-	listAr, errA := mpds.Query(dsq.Query{})
-	listBr, errB := ktds.Query(dsq.Query{})
-	c.Check(errA, Equals, nil)
-	c.Check(errB, Equals, nil)
+	run := func(d ds.Datastore, q dsq.Query) []ds.Key {
+		r, err := d.Query(q)
+		c.Check(err, Equals, nil)
 
-	listA := ds.EntryKeys(listAr.AllEntries())
-	listB := ds.EntryKeys(listBr.AllEntries())
+		e, err := r.Rest()
+		c.Check(err, Equals, nil)
+
+		return ds.EntryKeys(e)
+	}
+
+	listA := run(mpds, dsq.Query{})
+	listB := run(ktds, dsq.Query{})
 	c.Check(len(listA), Equals, len(listB))
 
 	// sort them cause yeah.

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/leveldb/datastore.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/leveldb/datastore.go
@@ -3,9 +3,12 @@ package leveldb
 import (
 	"io"
 
-	ds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/syndtr/goleveldb/leveldb"
 	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/syndtr/goleveldb/leveldb/util"
+
+	ds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
+	dsq "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
 )
 
 type Datastore interface {
@@ -69,13 +72,54 @@ func (d *datastore) Delete(key ds.Key) (err error) {
 	return err
 }
 
-func (d *datastore) KeyList() ([]ds.Key, error) {
-	i := d.DB.NewIterator(nil, nil)
-	var keys []ds.Key
-	for i.Next() {
-		keys = append(keys, ds.NewKey(string(i.Key())))
+func (d *datastore) Query(q dsq.Query) (*dsq.Results, error) {
+	var rnge *util.Range
+	if q.Prefix != "" {
+		rnge = util.BytesPrefix([]byte(q.Prefix))
 	}
-	return keys, nil
+	i := d.DB.NewIterator(rnge, nil)
+
+	// offset
+	if q.Offset > 0 {
+		for j := 0; j < q.Offset; j++ {
+			i.Next()
+		}
+	}
+
+	var es []dsq.Entry
+	for i.Next() {
+
+		// limit
+		if q.Limit > 0 && len(es) >= q.Limit {
+			break
+		}
+
+		k := ds.NewKey(string(i.Key())).String()
+		e := dsq.Entry{Key: k}
+
+		if !q.KeysOnly {
+			buf := make([]byte, len(i.Value()))
+			copy(buf, i.Value())
+			e.Value = buf
+		}
+
+		es = append(es, e)
+	}
+	i.Release()
+	if err := i.Error(); err != nil {
+		return nil, err
+	}
+
+	// Now, apply remaining pieces.
+	q2 := q
+	q2.Offset = 0 // already applied
+	q2.Limit = 0  // already applied
+	// TODO: make this async with:
+	// qr := dsq.ResultsWithEntriesChan(q, ch)
+	qr := dsq.ResultsWithEntries(q, es)
+	qr = q2.ApplyTo(qr)
+	qr.Query = q // set it back
+	return qr, nil
 }
 
 // LevelDB needs to be closed.

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/leveldb/ds_test.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/leveldb/ds_test.go
@@ -1,0 +1,99 @@
+package leveldb
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	ds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
+	dsq "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
+)
+
+var testcases = map[string]string{
+	"/a":     "a",
+	"/a/b":   "ab",
+	"/a/b/c": "abc",
+	"/a/b/d": "a/b/d",
+	"/a/c":   "ac",
+	"/a/d":   "ad",
+	"/e":     "e",
+	"/f":     "f",
+}
+
+func TestQuery(t *testing.T) {
+	path, err := ioutil.TempDir("/tmp", "testing_leveldb_")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		os.RemoveAll(path)
+	}()
+
+	d, err := NewDatastore(path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	for k, v := range testcases {
+		dsk := ds.NewKey(k)
+		if err := d.Put(dsk, []byte(v)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for k, v := range testcases {
+		dsk := ds.NewKey(k)
+		v2, err := d.Get(dsk)
+		if err != nil {
+			t.Fatal(err)
+		}
+		v2b := v2.([]byte)
+		if string(v2b) != v {
+			t.Errorf("%s values differ: %s != %s", k, v, v2)
+		}
+	}
+
+	rs, err := d.Query(dsq.Query{Prefix: "/a/"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectMatches(t, []string{
+		"/a/b",
+		"/a/b/c",
+		"/a/b/d",
+		"/a/c",
+		"/a/d",
+	}, rs.AllEntries())
+
+	// test offset and limit
+
+	rs, err = d.Query(dsq.Query{Prefix: "/a/", Offset: 2, Limit: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectMatches(t, []string{
+		"/a/b/d",
+		"/a/c",
+	}, rs.AllEntries())
+
+}
+
+func expectMatches(t *testing.T, expect []string, actual []dsq.Entry) {
+	if len(actual) != len(expect) {
+		t.Error("not enough", expect, actual)
+	}
+	for _, k := range expect {
+		found := false
+		for _, e := range actual {
+			if e.Key == k {
+				found = true
+			}
+		}
+		if !found {
+			t.Error(k, "not found")
+		}
+	}
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/lru/datastore.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/lru/datastore.go
@@ -51,6 +51,6 @@ func (d *Datastore) Delete(key ds.Key) (err error) {
 }
 
 // KeyList returns a list of keys in the datastore
-func (d *Datastore) Query(q dsq.Query) (*dsq.Results, error) {
+func (d *Datastore) Query(q dsq.Query) (dsq.Results, error) {
 	return nil, errors.New("KeyList not implemented.")
 }

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/lru/datastore.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/lru/datastore.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 
 	lru "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/hashicorp/golang-lru"
+
 	ds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
+	dsq "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
 )
 
 // Datastore uses golang-lru for internal storage.
@@ -49,6 +51,6 @@ func (d *Datastore) Delete(key ds.Key) (err error) {
 }
 
 // KeyList returns a list of keys in the datastore
-func (d *Datastore) KeyList() ([]ds.Key, error) {
+func (d *Datastore) Query(q dsq.Query) (*dsq.Results, error) {
 	return nil, errors.New("KeyList not implemented.")
 }

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/namespace/namespace_test.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/namespace/namespace_test.go
@@ -48,13 +48,18 @@ func (ks *DSSuite) TestBasic(c *C) {
 		c.Check(bytes.Equal(v2.([]byte), []byte(k.String())), Equals, true)
 	}
 
-	listAr, errA := mpds.Query(dsq.Query{})
-	listBr, errB := nsds.Query(dsq.Query{})
-	c.Check(errA, Equals, nil)
-	c.Check(errB, Equals, nil)
+	run := func(d ds.Datastore, q dsq.Query) []ds.Key {
+		r, err := d.Query(q)
+		c.Check(err, Equals, nil)
 
-	listA := ds.EntryKeys(listAr.AllEntries())
-	listB := ds.EntryKeys(listBr.AllEntries())
+		e, err := r.Rest()
+		c.Check(err, Equals, nil)
+
+		return ds.EntryKeys(e)
+	}
+
+	listA := run(mpds, dsq.Query{})
+	listB := run(nsds, dsq.Query{})
 	c.Check(len(listA), Equals, len(listB))
 
 	// sort them cause yeah.

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/namespace/namespace_test.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/namespace/namespace_test.go
@@ -5,9 +5,11 @@ import (
 	"sort"
 	"testing"
 
+	. "launchpad.net/gocheck"
+
 	ds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	ns "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/namespace"
-	. "launchpad.net/gocheck"
+	dsq "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -46,10 +48,13 @@ func (ks *DSSuite) TestBasic(c *C) {
 		c.Check(bytes.Equal(v2.([]byte), []byte(k.String())), Equals, true)
 	}
 
-	listA, errA := mpds.KeyList()
-	listB, errB := nsds.KeyList()
+	listAr, errA := mpds.Query(dsq.Query{})
+	listBr, errB := nsds.Query(dsq.Query{})
 	c.Check(errA, Equals, nil)
 	c.Check(errB, Equals, nil)
+
+	listA := ds.EntryKeys(listAr.AllEntries())
+	listB := ds.EntryKeys(listBr.AllEntries())
 	c.Check(len(listA), Equals, len(listB))
 
 	// sort them cause yeah.

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/panic/panic.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/panic/panic.go
@@ -58,7 +58,7 @@ func (d *datastore) Delete(key ds.Key) error {
 	return nil
 }
 
-func (d *datastore) Query(q dsq.Query) (*dsq.Results, error) {
+func (d *datastore) Query(q dsq.Query) (dsq.Results, error) {
 	r, err := d.child.Query(q)
 	if err != nil {
 		fmt.Fprintf(os.Stdout, "panic datastore: %s", err)

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/panic/panic.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/panic/panic.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	ds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
+	dsq "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
 )
 
 type datastore struct {
@@ -57,11 +58,11 @@ func (d *datastore) Delete(key ds.Key) error {
 	return nil
 }
 
-func (d *datastore) KeyList() ([]ds.Key, error) {
-	kl, err := d.child.KeyList()
+func (d *datastore) Query(q dsq.Query) (*dsq.Results, error) {
+	r, err := d.child.Query(q)
 	if err != nil {
 		fmt.Fprintf(os.Stdout, "panic datastore: %s", err)
-		panic("panic datastore: KeyList failed")
+		panic("panic datastore: Query failed")
 	}
-	return kl, nil
+	return r, nil
 }

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/filter.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/filter.go
@@ -1,0 +1,86 @@
+package query
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// Filter is an object that tests ResultEntries
+type Filter interface {
+	// Filter returns whether an entry passes the filter
+	Filter(e Entry) bool
+}
+
+// Op is a comparison operator
+type Op string
+
+var (
+	Equal              = Op("==")
+	NotEqual           = Op("!=")
+	GreaterThan        = Op(">")
+	GreaterThanOrEqual = Op(">=")
+	LessThan           = Op("<")
+	LessThanOrEqual    = Op("<=")
+)
+
+// FilterValueCompare is used to signal to datastores they
+// should apply internal comparisons. unfortunately, there
+// is no way to apply comparisons* to interface{} types in
+// Go, so if the datastore doesnt have a special way to
+// handle these comparisons, you must provided the
+// TypedFilter to actually do filtering.
+//
+// [*] other than == and !=, which use reflect.DeepEqual.
+type FilterValueCompare struct {
+	Op          Op
+	Value       interface{}
+	TypedFilter Filter
+}
+
+func (f FilterValueCompare) Filter(e Entry) bool {
+	if f.TypedFilter != nil {
+		return f.TypedFilter.Filter(e)
+	}
+
+	switch f.Op {
+	case Equal:
+		return reflect.DeepEqual(f.Value, e.Value)
+	case NotEqual:
+		return !reflect.DeepEqual(f.Value, e.Value)
+	default:
+		panic(fmt.Errorf("cannot apply op '%s' to interface{}.", f.Op))
+	}
+}
+
+type FilterKeyCompare struct {
+	Op  Op
+	Key string
+}
+
+func (f FilterKeyCompare) Filter(e Entry) bool {
+	switch f.Op {
+	case Equal:
+		return e.Key == f.Key
+	case NotEqual:
+		return e.Key != f.Key
+	case GreaterThan:
+		return e.Key > f.Key
+	case GreaterThanOrEqual:
+		return e.Key >= f.Key
+	case LessThan:
+		return e.Key < f.Key
+	case LessThanOrEqual:
+		return e.Key <= f.Key
+	default:
+		panic(fmt.Errorf("unknown op '%s'", f.Op))
+	}
+}
+
+type FilterKeyPrefix struct {
+	Prefix string
+}
+
+func (f FilterKeyPrefix) Filter(e Entry) bool {
+	return strings.HasPrefix(e.Key, f.Prefix)
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/filter_test.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/filter_test.go
@@ -5,15 +5,6 @@ import (
 	"testing"
 )
 
-var sampleKeys = []string{
-	"/ab/c",
-	"/ab/cd",
-	"/a",
-	"/abce",
-	"/abcf",
-	"/ab",
-}
-
 type filterTestCase struct {
 	filter Filter
 	keys   []string
@@ -28,7 +19,10 @@ func testKeyFilter(t *testing.T, f Filter, keys []string, expect []string) {
 
 	res := ResultsWithEntries(Query{}, e)
 	res = NaiveFilter(res, f)
-	actualE := res.AllEntries()
+	actualE, err := res.Rest()
+	if err != nil {
+		t.Fatal(err)
+	}
 	actual := make([]string, len(actualE))
 	for i, e := range actualE {
 		actual[i] = e.Key

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/filter_test.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/filter_test.go
@@ -1,0 +1,75 @@
+package query
+
+import (
+	"strings"
+	"testing"
+)
+
+var sampleKeys = []string{
+	"/ab/c",
+	"/ab/cd",
+	"/a",
+	"/abce",
+	"/abcf",
+	"/ab",
+}
+
+type filterTestCase struct {
+	filter Filter
+	keys   []string
+	expect []string
+}
+
+func testKeyFilter(t *testing.T, f Filter, keys []string, expect []string) {
+	e := make([]Entry, len(keys))
+	for i, k := range keys {
+		e[i] = Entry{Key: k}
+	}
+
+	res := ResultsWithEntries(Query{}, e)
+	res = NaiveFilter(res, f)
+	actualE := res.AllEntries()
+	actual := make([]string, len(actualE))
+	for i, e := range actualE {
+		actual[i] = e.Key
+	}
+
+	if len(actual) != len(expect) {
+		t.Error("expect != actual.", expect, actual)
+	}
+
+	if strings.Join(actual, "") != strings.Join(expect, "") {
+		t.Error("expect != actual.", expect, actual)
+	}
+}
+
+func TestFilterKeyCompare(t *testing.T) {
+
+	testKeyFilter(t, FilterKeyCompare{Equal, "/ab"}, sampleKeys, []string{"/ab"})
+	testKeyFilter(t, FilterKeyCompare{GreaterThan, "/ab"}, sampleKeys, []string{
+		"/ab/c",
+		"/ab/cd",
+		"/abce",
+		"/abcf",
+	})
+	testKeyFilter(t, FilterKeyCompare{LessThanOrEqual, "/ab"}, sampleKeys, []string{
+		"/a",
+		"/ab",
+	})
+}
+
+func TestFilterKeyPrefix(t *testing.T) {
+
+	testKeyFilter(t, FilterKeyPrefix{"/a"}, sampleKeys, []string{
+		"/ab/c",
+		"/ab/cd",
+		"/a",
+		"/abce",
+		"/abcf",
+		"/ab",
+	})
+	testKeyFilter(t, FilterKeyPrefix{"/ab/"}, sampleKeys, []string{
+		"/ab/c",
+		"/ab/cd",
+	})
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/order.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/order.go
@@ -1,0 +1,66 @@
+package query
+
+import (
+	"sort"
+)
+
+// Order is an object used to order objects
+type Order interface {
+
+	// Sort sorts the Entry slice according to
+	// the Order criteria.
+	Sort([]Entry)
+}
+
+// OrderByValue is used to signal to datastores they
+// should apply internal orderings. unfortunately, there
+// is no way to apply order comparisons to interface{} types
+// in Go, so if the datastore doesnt have a special way to
+// handle these comparisons, you must provide an Order
+// implementation that casts to the correct type.
+type OrderByValue struct {
+	TypedOrder Order
+}
+
+func (o OrderByValue) Sort(res []Entry) {
+	if o.TypedOrder == nil {
+		panic("cannot order interface{} by value. see query docs.")
+	}
+	o.TypedOrder.Sort(res)
+}
+
+// OrderByValueDescending is used to signal to datastores they
+// should apply internal orderings. unfortunately, there
+// is no way to apply order comparisons to interface{} types
+// in Go, so if the datastore doesnt have a special way to
+// handle these comparisons, you are SOL.
+type OrderByValueDescending struct {
+	TypedOrder Order
+}
+
+func (o OrderByValueDescending) Sort(res []Entry) {
+	if o.TypedOrder == nil {
+		panic("cannot order interface{} by value. see query docs.")
+	}
+	o.TypedOrder.Sort(res)
+}
+
+// OrderByKey
+type OrderByKey struct{}
+
+func (o OrderByKey) Sort(res []Entry) {
+	sort.Stable(reByKey(res))
+}
+
+// OrderByKeyDescending
+type OrderByKeyDescending struct{}
+
+func (o OrderByKeyDescending) Sort(res []Entry) {
+	sort.Stable(sort.Reverse(reByKey(res)))
+}
+
+type reByKey []Entry
+
+func (s reByKey) Len() int           { return len(s) }
+func (s reByKey) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s reByKey) Less(i, j int) bool { return s[i].Key < s[j].Key }

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/order_test.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/order_test.go
@@ -19,7 +19,11 @@ func testKeyOrder(t *testing.T, f Order, keys []string, expect []string) {
 
 	res := ResultsWithEntries(Query{}, e)
 	res = NaiveOrder(res, f)
-	actualE := res.AllEntries()
+	actualE, err := res.Rest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	actual := make([]string, len(actualE))
 	for i, e := range actualE {
 		actual[i] = e.Key

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/order_test.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/order_test.go
@@ -1,0 +1,55 @@
+package query
+
+import (
+	"strings"
+	"testing"
+)
+
+type orderTestCase struct {
+	order  Order
+	keys   []string
+	expect []string
+}
+
+func testKeyOrder(t *testing.T, f Order, keys []string, expect []string) {
+	e := make([]Entry, len(keys))
+	for i, k := range keys {
+		e[i] = Entry{Key: k}
+	}
+
+	res := ResultsWithEntries(Query{}, e)
+	res = NaiveOrder(res, f)
+	actualE := res.AllEntries()
+	actual := make([]string, len(actualE))
+	for i, e := range actualE {
+		actual[i] = e.Key
+	}
+
+	if len(actual) != len(expect) {
+		t.Error("expect != actual.", expect, actual)
+	}
+
+	if strings.Join(actual, "") != strings.Join(expect, "") {
+		t.Error("expect != actual.", expect, actual)
+	}
+}
+
+func TestOrderByKey(t *testing.T) {
+
+	testKeyOrder(t, OrderByKey{}, sampleKeys, []string{
+		"/a",
+		"/ab",
+		"/ab/c",
+		"/ab/cd",
+		"/abce",
+		"/abcf",
+	})
+	testKeyOrder(t, OrderByKeyDescending{}, sampleKeys, []string{
+		"/abcf",
+		"/abce",
+		"/ab/cd",
+		"/ab/c",
+		"/ab",
+		"/a",
+	})
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/query.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/query.go
@@ -1,0 +1,145 @@
+package query
+
+/*
+Query represents storage for any key-value pair.
+
+tl;dr:
+
+  queries are supported across datastores.
+  Cheap on top of relational dbs, and expensive otherwise.
+  Pick the right tool for the job!
+
+In addition to the key-value store get and set semantics, datastore
+provides an interface to retrieve multiple records at a time through
+the use of queries. The datastore Query model gleans a common set of
+operations performed when querying. To avoid pasting here years of
+database research, let’s summarize the operations datastore supports.
+
+Query Operations:
+
+  * namespace - scope the query, usually by object type
+  * filters - select a subset of values by applying constraints
+  * orders - sort the results by applying sort conditions
+  * limit - impose a numeric limit on the number of results
+  * offset - skip a number of results (for efficient pagination)
+
+datastore combines these operations into a simple Query class that allows
+applications to define their constraints in a simple, generic, way without
+introducing datastore specific calls, languages, etc.
+
+Of course, different datastores provide relational query support across a
+wide spectrum, from full support in traditional databases to none at all in
+most key-value stores. Datastore aims to provide a common, simple interface
+for the sake of application evolution over time and keeping large code bases
+free of tool-specific code. It would be ridiculous to claim to support high-
+performance queries on architectures that obviously do not. Instead, datastore
+provides the interface, ideally translating queries to their native form
+(e.g. into SQL for MySQL).
+
+However, on the wrong datastore, queries can potentially incur the high cost
+of performing the aforemantioned query operations on the data set directly in
+Go. It is the client’s responsibility to select the right tool for the job:
+pick a data storage solution that fits the application’s needs now, and wrap
+it with a datastore implementation. As the needs change, swap out datastore
+implementations to support your new use cases. Some applications, particularly
+in early development stages, can afford to incurr the cost of queries on non-
+relational databases (e.g. using a FSDatastore and not worry about a database
+at all). When it comes time to switch the tool for performance, updating the
+application code can be as simple as swapping the datastore in one place, not
+all over the application code base. This gain in engineering time, both at
+initial development and during later iterations, can significantly offset the
+cost of the layer of abstraction.
+
+*/
+type Query struct {
+	Prefix   string   // namespaces the query to results whose keys have Prefix
+	Filters  []Filter // filter results. apply sequentially
+	Orders   []Order  // order results. apply sequentially
+	Limit    int      // maximum number of results
+	Offset   int      // skip given number of results
+	KeysOnly bool     // return only keys.
+}
+
+// NotFetched is a special type that signals whether or not the value
+// of an Entry has been fetched or not. This is needed because
+// datastore implementations get to decide whether Query returns values
+// or only keys. nil is not a good signal, as real values may be nil.
+var NotFetched = struct{}{}
+
+// Entry is a query result entry.
+type Entry struct {
+	Key   string // cant be ds.Key because circular imports ...!!!
+	Value interface{}
+}
+
+// Results is a set of Query results
+type Results struct {
+	Query Query // the query these Results correspond to
+
+	done chan struct{}
+	res  chan Entry
+	all  []Entry
+}
+
+// ResultsWithEntriesChan returns a Results object from a
+// channel of ResultEntries. It's merely an encapsulation
+// that provides for AllEntries() functionality.
+func ResultsWithEntriesChan(q Query, res <-chan Entry) *Results {
+	r := &Results{
+		Query: q,
+		done:  make(chan struct{}),
+		res:   make(chan Entry),
+		all:   []Entry{},
+	}
+
+	// go consume all the results and add them to the results.
+	go func() {
+		for e := range res {
+			r.all = append(r.all, e)
+			r.res <- e
+		}
+		close(r.res)
+		close(r.done)
+	}()
+	return r
+}
+
+// ResultsWithEntries returns a Results object from a
+// channel of ResultEntries. It's merely an encapsulation
+// that provides for AllEntries() functionality.
+func ResultsWithEntries(q Query, res []Entry) *Results {
+	r := &Results{
+		Query: q,
+		done:  make(chan struct{}),
+		res:   make(chan Entry),
+		all:   res,
+	}
+
+	// go add all the results
+	go func() {
+		for _, e := range res {
+			r.res <- e
+		}
+		close(r.res)
+		close(r.done)
+	}()
+	return r
+}
+
+// Entries() returns results through a channel.
+// Results may arrive at any time.
+// The channel may or may not be buffered.
+// The channel may or may not rate limit the query processing.
+func (r *Results) Entries() <-chan Entry {
+	return r.res
+}
+
+// AllEntries returns all the entries in Results.
+// It blocks until all the results have come in.
+func (r *Results) AllEntries() []Entry {
+	for e := range r.res {
+		_ = e
+	}
+	<-r.done
+	return r.all
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/query_impl.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/query_impl.go
@@ -1,0 +1,85 @@
+package query
+
+// NaiveFilter applies a filter to the results
+func NaiveFilter(qr *Results, filter Filter) *Results {
+	ch := make(chan Entry)
+	go func() {
+		defer close(ch)
+
+		for e := range qr.Entries() {
+			if filter.Filter(e) {
+				ch <- e
+			}
+		}
+	}()
+	return ResultsWithEntriesChan(qr.Query, ch)
+}
+
+// NaiveLimit truncates the results to a given int limit
+func NaiveLimit(qr *Results, limit int) *Results {
+	ch := make(chan Entry)
+	go func() {
+		defer close(ch)
+
+		for l := 0; l < limit; l++ {
+			e, more := <-qr.Entries()
+			if !more {
+				return
+			}
+			ch <- e
+		}
+	}()
+	return ResultsWithEntriesChan(qr.Query, ch)
+}
+
+// NaiveOffset skips a given number of results
+func NaiveOffset(qr *Results, offset int) *Results {
+	ch := make(chan Entry)
+	go func() {
+		defer close(ch)
+
+		for l := 0; l < offset; l++ {
+			<-qr.Entries() // discard
+		}
+
+		for e := range qr.Entries() {
+			ch <- e
+		}
+	}()
+	return ResultsWithEntriesChan(qr.Query, ch)
+}
+
+// NaiveOrder reorders results according to given Order.
+// WARNING: this is the only non-stream friendly operation!
+func NaiveOrder(qr *Results, o Order) *Results {
+	e := qr.AllEntries()
+	o.Sort(e)
+	return ResultsWithEntries(qr.Query, e)
+}
+
+func (q Query) ApplyTo(qr *Results) *Results {
+	if q.Prefix != "" {
+		qr = NaiveFilter(qr, FilterKeyPrefix{q.Prefix})
+	}
+	for _, f := range q.Filters {
+		qr = NaiveFilter(qr, f)
+	}
+	for _, o := range q.Orders {
+		qr = NaiveOrder(qr, o)
+	}
+	if q.Offset != 0 {
+		qr = NaiveOffset(qr, q.Offset)
+	}
+	if q.Limit != 0 {
+		qr = NaiveLimit(qr, q.Offset)
+	}
+	return qr
+}
+
+func ResultEntriesFrom(keys []string, vals []interface{}) []Entry {
+	re := make([]Entry, len(keys))
+	for i, k := range keys {
+		re[i] = Entry{Key: k, Value: vals[i]}
+	}
+	return re
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/query_impl.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/query_impl.go
@@ -1,63 +1,105 @@
 package query
 
-// NaiveFilter applies a filter to the results
-func NaiveFilter(qr *Results, filter Filter) *Results {
-	ch := make(chan Entry)
+func DerivedResults(qr Results, ch <-chan Result) Results {
+	return &results{
+		query: qr.Query(),
+		proc:  qr.Process(),
+		res:   ch,
+	}
+}
+
+// NaiveFilter applies a filter to the results.
+func NaiveFilter(qr Results, filter Filter) Results {
+	ch := make(chan Result)
 	go func() {
 		defer close(ch)
+		defer qr.Close()
 
-		for e := range qr.Entries() {
-			if filter.Filter(e) {
+		for e := range qr.Next() {
+			if e.Error != nil || filter.Filter(e.Entry) {
 				ch <- e
 			}
 		}
 	}()
-	return ResultsWithEntriesChan(qr.Query, ch)
+
+	return DerivedResults(qr, ch)
 }
 
 // NaiveLimit truncates the results to a given int limit
-func NaiveLimit(qr *Results, limit int) *Results {
-	ch := make(chan Entry)
+func NaiveLimit(qr Results, limit int) Results {
+	ch := make(chan Result)
 	go func() {
 		defer close(ch)
+		defer qr.Close()
 
-		for l := 0; l < limit; l++ {
-			e, more := <-qr.Entries()
-			if !more {
-				return
+		l := 0
+		for e := range qr.Next() {
+			if e.Error != nil {
+				ch <- e
+				continue
+			}
+			ch <- e
+			l++
+			if limit > 0 && l >= limit {
+				break
+			}
+		}
+	}()
+
+	return DerivedResults(qr, ch)
+}
+
+// NaiveOffset skips a given number of results
+func NaiveOffset(qr Results, offset int) Results {
+	ch := make(chan Result)
+	go func() {
+		defer close(ch)
+		defer qr.Close()
+
+		sent := 0
+		for e := range qr.Next() {
+			if e.Error != nil {
+				ch <- e
+			}
+
+			if sent < offset {
+				sent++
+				continue
 			}
 			ch <- e
 		}
 	}()
-	return ResultsWithEntriesChan(qr.Query, ch)
-}
 
-// NaiveOffset skips a given number of results
-func NaiveOffset(qr *Results, offset int) *Results {
-	ch := make(chan Entry)
-	go func() {
-		defer close(ch)
-
-		for l := 0; l < offset; l++ {
-			<-qr.Entries() // discard
-		}
-
-		for e := range qr.Entries() {
-			ch <- e
-		}
-	}()
-	return ResultsWithEntriesChan(qr.Query, ch)
+	return DerivedResults(qr, ch)
 }
 
 // NaiveOrder reorders results according to given Order.
 // WARNING: this is the only non-stream friendly operation!
-func NaiveOrder(qr *Results, o Order) *Results {
-	e := qr.AllEntries()
-	o.Sort(e)
-	return ResultsWithEntries(qr.Query, e)
+func NaiveOrder(qr Results, o Order) Results {
+	ch := make(chan Result)
+	var entries []Entry
+	go func() {
+		defer close(ch)
+		defer qr.Close()
+
+		for e := range qr.Next() {
+			if e.Error != nil {
+				ch <- e
+			}
+
+			entries = append(entries, e.Entry)
+		}
+
+		o.Sort(entries)
+		for _, e := range entries {
+			ch <- Result{Entry: e}
+		}
+	}()
+
+	return DerivedResults(qr, ch)
 }
 
-func (q Query) ApplyTo(qr *Results) *Results {
+func NaiveQueryApply(q Query, qr Results) Results {
 	if q.Prefix != "" {
 		qr = NaiveFilter(qr, FilterKeyPrefix{q.Prefix})
 	}

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/query_test.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/query/query_test.go
@@ -1,0 +1,109 @@
+package query
+
+import (
+	"strings"
+	"testing"
+)
+
+var sampleKeys = []string{
+	"/ab/c",
+	"/ab/cd",
+	"/a",
+	"/abce",
+	"/abcf",
+	"/ab",
+}
+
+type testCase struct {
+	keys   []string
+	expect []string
+}
+
+func testResults(t *testing.T, res Results, expect []string) {
+	actualE, err := res.Rest()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual := make([]string, len(actualE))
+	for i, e := range actualE {
+		actual[i] = e.Key
+	}
+
+	if len(actual) != len(expect) {
+		t.Error("expect != actual.", expect, actual)
+	}
+
+	if strings.Join(actual, "") != strings.Join(expect, "") {
+		t.Error("expect != actual.", expect, actual)
+	}
+}
+
+func TestLimit(t *testing.T) {
+	testKeyLimit := func(t *testing.T, limit int, keys []string, expect []string) {
+		e := make([]Entry, len(keys))
+		for i, k := range keys {
+			e[i] = Entry{Key: k}
+		}
+
+		res := ResultsWithEntries(Query{}, e)
+		res = NaiveLimit(res, limit)
+		testResults(t, res, expect)
+	}
+
+	testKeyLimit(t, 0, sampleKeys, []string{ // none
+		"/ab/c",
+		"/ab/cd",
+		"/a",
+		"/abce",
+		"/abcf",
+		"/ab",
+	})
+
+	testKeyLimit(t, 10, sampleKeys, []string{ // large
+		"/ab/c",
+		"/ab/cd",
+		"/a",
+		"/abce",
+		"/abcf",
+		"/ab",
+	})
+
+	testKeyLimit(t, 2, sampleKeys, []string{
+		"/ab/c",
+		"/ab/cd",
+	})
+}
+
+func TestOffset(t *testing.T) {
+
+	testOffset := func(t *testing.T, offset int, keys []string, expect []string) {
+		e := make([]Entry, len(keys))
+		for i, k := range keys {
+			e[i] = Entry{Key: k}
+		}
+
+		res := ResultsWithEntries(Query{}, e)
+		res = NaiveOffset(res, offset)
+		testResults(t, res, expect)
+	}
+
+	testOffset(t, 0, sampleKeys, []string{ // none
+		"/ab/c",
+		"/ab/cd",
+		"/a",
+		"/abce",
+		"/abcf",
+		"/ab",
+	})
+
+	testOffset(t, 10, sampleKeys, []string{ // large
+	})
+
+	testOffset(t, 2, sampleKeys, []string{
+		"/a",
+		"/abce",
+		"/abcf",
+		"/ab",
+	})
+}

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync/sync.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync/sync.go
@@ -58,7 +58,7 @@ func (d *MutexDatastore) Delete(key ds.Key) (err error) {
 }
 
 // KeyList implements Datastore.KeyList
-func (d *MutexDatastore) Query(q dsq.Query) (*dsq.Results, error) {
+func (d *MutexDatastore) Query(q dsq.Query) (dsq.Results, error) {
 	d.RLock()
 	defer d.RUnlock()
 	return d.child.Query(q)

--- a/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync/sync.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync/sync.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	ds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
+	dsq "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
 )
 
 // MutexDatastore contains a child datastire and a mutex.
@@ -57,8 +58,8 @@ func (d *MutexDatastore) Delete(key ds.Key) (err error) {
 }
 
 // KeyList implements Datastore.KeyList
-func (d *MutexDatastore) KeyList() ([]ds.Key, error) {
+func (d *MutexDatastore) Query(q dsq.Query) (*dsq.Results, error) {
 	d.RLock()
 	defer d.RUnlock()
-	return d.child.KeyList()
+	return d.child.Query(q)
 }

--- a/Godeps/_workspace/src/github.com/jbenet/goprocess/impl-mutex.go
+++ b/Godeps/_workspace/src/github.com/jbenet/goprocess/impl-mutex.go
@@ -9,6 +9,7 @@ type process struct {
 	children []Process     // process to close with us
 	waitfors []Process     // process to only wait for
 	teardown TeardownFunc  // called to run the teardown logic.
+	waiting  chan struct{} // closed when CloseAfterChildrenClosed is called.
 	closing  chan struct{} // closed once close starts.
 	closed   chan struct{} // closed once close is done.
 	closeErr error         // error to return to clients of Close()
@@ -73,13 +74,18 @@ func (p *process) AddChild(child Process) {
 	p.Unlock()
 }
 
-func (p *process) Go(f ProcessFunc) {
+func (p *process) Go(f ProcessFunc) Process {
 	child := newProcess(nil)
 	p.AddChild(child)
+
+	waitFor := newProcess(nil)
+	child.WaitFor(waitFor) // prevent child from closing
 	go func() {
 		f(child)
-		child.Close() // close to tear down.
+		waitFor.Close() // allow child to close.
+		child.Close()   // close to tear down.
 	}()
+	return child
 }
 
 // Close is the external close function.
@@ -124,4 +130,47 @@ func (p *process) doClose() {
 
 	p.closeErr = p.teardown() // actually run the close logic (ok safe to teardown)
 	close(p.closed)           // signal that we're shut down (Closed)
+}
+
+// We will only wait on the children we have now.
+// We will not wait on children added subsequently.
+// this may change in the future.
+func (p *process) CloseAfterChildren() error {
+	p.Lock()
+	select {
+	case <-p.Closed():
+		p.Unlock()
+		return p.Close() // get error. safe, after p.Closed()
+	case <-p.waiting: // already called it.
+		p.Unlock()
+		<-p.Closed()
+		return p.Close() // get error. safe, after p.Closed()
+	default:
+	}
+	p.Unlock()
+
+	// here only from one goroutine.
+
+	nextToWaitFor := func() Process {
+		p.Lock()
+		defer p.Unlock()
+		for _, e := range p.waitfors {
+			select {
+			case <-e.Closed():
+			default:
+				return e
+			}
+		}
+		return nil
+	}
+
+	// wait for all processes we're waiting for are closed.
+	// the semantics here are simple: we will _only_ close
+	// if there are no processes currently waiting for.
+	for next := nextToWaitFor(); next != nil; next = nextToWaitFor() {
+		<-next.Closed()
+	}
+
+	// YAY! we're done. close
+	return p.Close()
 }

--- a/blocks/blockstore/blockstore.go
+++ b/blocks/blockstore/blockstore.go
@@ -19,7 +19,7 @@ import (
 var log = eventlog.Logger("blockstore")
 
 // BlockPrefix namespaces blockstore datastores
-var BlockPrefix = ds.NewKey("blocks")
+var BlockPrefix = ds.NewKey("b")
 
 var ValueTypeMismatch = errors.New("The retrieved value is not a Block")
 

--- a/blocks/blockstore/blockstore.go
+++ b/blocks/blockstore/blockstore.go
@@ -132,6 +132,7 @@ func (bs *blockstore) AllKeysChan(ctx context.Context, offset int, limit int) (<
 
 			// need to convert to u.Key using u.KeyFromDsKey.
 			k = u.KeyFromDsKey(ds.NewKey(e.Key))
+			log.Debug("blockstore: query got key", k)
 			return k, true
 		}
 	}

--- a/blocks/blockstore/blockstore.go
+++ b/blocks/blockstore/blockstore.go
@@ -133,6 +133,13 @@ func (bs *blockstore) AllKeysChan(ctx context.Context, offset int, limit int) (<
 			// need to convert to u.Key using u.KeyFromDsKey.
 			k = u.KeyFromDsKey(ds.NewKey(e.Key))
 			log.Debug("blockstore: query got key", k)
+
+			// key must be a multihash. else ignore it.
+			_, err := mh.Cast([]byte(k))
+			if err != nil {
+				return "", true
+			}
+
 			return k, true
 		}
 	}
@@ -148,6 +155,9 @@ func (bs *blockstore) AllKeysChan(ctx context.Context, offset int, limit int) (<
 			k, ok := get()
 			if !ok {
 				return
+			}
+			if k == "" {
+				continue
 			}
 
 			select {

--- a/blocks/blockstore/blockstore_test.go
+++ b/blocks/blockstore/blockstore_test.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"testing"
 
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
 	ds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
+	dsq "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
 	ds_sync "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync"
+
 	blocks "github.com/jbenet/go-ipfs/blocks"
 	u "github.com/jbenet/go-ipfs/util"
 )
@@ -42,9 +45,11 @@ func TestPutThenGetBlock(t *testing.T) {
 	}
 }
 
-func TestAllKeys(t *testing.T) {
-	bs := NewBlockstore(ds_sync.MutexWrap(ds.NewMapDatastore()))
-	N := 100
+func newBlockStoreWithKeys(t *testing.T, d ds.Datastore, N int) (Blockstore, []u.Key) {
+	if d == nil {
+		d = ds.NewMapDatastore()
+	}
+	bs := NewBlockstore(ds_sync.MutexWrap(d))
 
 	keys := make([]u.Key, N)
 	for i := 0; i < N; i++ {
@@ -55,8 +60,14 @@ func TestAllKeys(t *testing.T) {
 		}
 		keys[i] = block.Key()
 	}
+	return bs, keys
+}
 
-	keys2, err := bs.AllKeys(0, 0)
+func TestAllKeysSimple(t *testing.T) {
+	bs, keys := newBlockStoreWithKeys(t, nil, 100)
+
+	ctx := context.Background()
+	keys2, err := bs.AllKeys(ctx, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,8 +76,14 @@ func TestAllKeys(t *testing.T) {
 	// }
 
 	expectMatches(t, keys, keys2)
+}
 
-	keys3, err := bs.AllKeys(N/3, N/3)
+func TestAllKeysOffsetAndLimit(t *testing.T) {
+	N := 30
+	bs, _ := newBlockStoreWithKeys(t, nil, N)
+
+	ctx := context.Background()
+	keys3, err := bs.AllKeys(ctx, N/3, N/3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,6 +92,114 @@ func TestAllKeys(t *testing.T) {
 	}
 	if len(keys3) != N/3 {
 		t.Errorf("keys3 should be: %d != %d", N/3, len(keys3))
+	}
+}
+
+func TestAllKeysRespectsContext(t *testing.T) {
+	N := 100
+
+	d := &queryTestDS{ds: ds.NewMapDatastore()}
+	bs, _ := newBlockStoreWithKeys(t, d, N)
+
+	started := make(chan struct{}, 1)
+	done := make(chan struct{}, 1)
+	errors := make(chan error, 100)
+
+	getKeys := func(ctx context.Context) {
+		started <- struct{}{}
+		_, err := bs.AllKeys(ctx, 0, 0) // once without cancelling
+		if err != nil {
+			errors <- err
+		}
+		done <- struct{}{}
+		errors <- nil // a nil one to signal break
+	}
+
+	// Once without context, to make sure it all works
+	{
+		var results dsq.Results
+		resultChan := make(chan dsq.Result)
+		d.SetFunc(func(q dsq.Query) (dsq.Results, error) {
+			results = dsq.ResultsWithChan(q, resultChan)
+			return results, nil
+		})
+
+		go getKeys(context.Background())
+
+		// make sure it's waiting.
+		<-started
+		select {
+		case <-done:
+			t.Fatal("sync is wrong")
+		case <-results.Process().Closing():
+			t.Fatal("should not be closing")
+		case <-results.Process().Closed():
+			t.Fatal("should not be closed")
+		default:
+		}
+
+		e := dsq.Entry{Key: BlockPrefix.ChildString("foo").String()}
+		resultChan <- dsq.Result{Entry: e} // let it go.
+		close(resultChan)
+		<-done                       // should be done now.
+		<-results.Process().Closed() // should be closed now
+
+		// print any errors
+		for err := range errors {
+			if err == nil {
+				break
+			}
+			t.Error(err)
+		}
+	}
+
+	// Once with
+	{
+		var results dsq.Results
+		resultChan := make(chan dsq.Result)
+		d.SetFunc(func(q dsq.Query) (dsq.Results, error) {
+			results = dsq.ResultsWithChan(q, resultChan)
+			return results, nil
+		})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go getKeys(ctx)
+
+		// make sure it's waiting.
+		<-started
+		select {
+		case <-done:
+			t.Fatal("sync is wrong")
+		case <-results.Process().Closing():
+			t.Fatal("should not be closing")
+		case <-results.Process().Closed():
+			t.Fatal("should not be closed")
+		default:
+		}
+
+		cancel() // let it go.
+
+		select {
+		case <-done:
+			t.Fatal("sync is wrong")
+		case <-results.Process().Closed():
+			t.Fatal("should not be closed") // should not be closed yet.
+		case <-results.Process().Closing():
+			// should be closing now!
+			t.Log("closing correctly at this point.")
+		}
+
+		close(resultChan)
+		<-done                       // should be done now.
+		<-results.Process().Closed() // should be closed now
+
+		// print any errors
+		for err := range errors {
+			if err == nil {
+				break
+			}
+			t.Error(err)
+		}
 	}
 
 }
@@ -110,4 +235,34 @@ func expectMatches(t *testing.T, expect, actual []u.Key) {
 			t.Error("expected key not found: ", ek)
 		}
 	}
+}
+
+type queryTestDS struct {
+	cb func(q dsq.Query) (dsq.Results, error)
+	ds ds.Datastore
+}
+
+func (c *queryTestDS) SetFunc(f func(dsq.Query) (dsq.Results, error)) { c.cb = f }
+
+func (c *queryTestDS) Put(key ds.Key, value interface{}) (err error) {
+	return c.ds.Put(key, value)
+}
+
+func (c *queryTestDS) Get(key ds.Key) (value interface{}, err error) {
+	return c.ds.Get(key)
+}
+
+func (c *queryTestDS) Has(key ds.Key) (exists bool, err error) {
+	return c.ds.Has(key)
+}
+
+func (c *queryTestDS) Delete(key ds.Key) (err error) {
+	return c.ds.Delete(key)
+}
+
+func (c *queryTestDS) Query(q dsq.Query) (dsq.Results, error) {
+	if c.cb != nil {
+		return c.cb(q)
+	}
+	return c.ds.Query(q)
 }

--- a/blocks/blockstore/blockstore_test.go
+++ b/blocks/blockstore/blockstore_test.go
@@ -2,6 +2,7 @@ package blockstore
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	ds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
@@ -41,16 +42,72 @@ func TestPutThenGetBlock(t *testing.T) {
 	}
 }
 
+func TestAllKeys(t *testing.T) {
+	bs := NewBlockstore(ds_sync.MutexWrap(ds.NewMapDatastore()))
+	N := 100
+
+	keys := make([]u.Key, N)
+	for i := 0; i < N; i++ {
+		block := blocks.NewBlock([]byte(fmt.Sprintf("some data %d", i)))
+		err := bs.Put(block)
+		if err != nil {
+			t.Fatal(err)
+		}
+		keys[i] = block.Key()
+	}
+
+	keys2, err := bs.AllKeys(0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// for _, k2 := range keys2 {
+	// 	t.Log("found ", k2.Pretty())
+	// }
+
+	expectMatches(t, keys, keys2)
+
+	keys3, err := bs.AllKeys(N/3, N/3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, k3 := range keys3 {
+		t.Log("found ", k3.Pretty())
+	}
+	if len(keys3) != N/3 {
+		t.Errorf("keys3 should be: %d != %d", N/3, len(keys3))
+	}
+
+}
+
 func TestValueTypeMismatch(t *testing.T) {
 	block := blocks.NewBlock([]byte("some data"))
 
 	datastore := ds.NewMapDatastore()
-	datastore.Put(block.Key().DsKey(), "data that isn't a block!")
+	k := BlockPrefix.Child(block.Key().DsKey())
+	datastore.Put(k, "data that isn't a block!")
 
 	blockstore := NewBlockstore(ds_sync.MutexWrap(datastore))
 
 	_, err := blockstore.Get(block.Key())
 	if err != ValueTypeMismatch {
 		t.Fatal(err)
+	}
+}
+
+func expectMatches(t *testing.T, expect, actual []u.Key) {
+
+	if len(expect) != len(actual) {
+		t.Errorf("expect and actual differ: %d != %d", len(expect), len(actual))
+	}
+	for _, ek := range expect {
+		found := false
+		for _, ak := range actual {
+			if ek == ak {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected key not found: ", ek)
+		}
 	}
 }

--- a/blocks/blockstore/write_cache.go
+++ b/blocks/blockstore/write_cache.go
@@ -43,3 +43,7 @@ func (w *writecache) Put(b *blocks.Block) error {
 	w.cache.Add(b.Key(), struct{}{})
 	return w.blockstore.Put(b)
 }
+
+func (w *writecache) AllKeys(offset int, limit int) ([]u.Key, error) {
+	return w.blockstore.AllKeys(offset, limit)
+}

--- a/blocks/blockstore/write_cache.go
+++ b/blocks/blockstore/write_cache.go
@@ -1,7 +1,9 @@
 package blockstore
 
 import (
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
 	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/hashicorp/golang-lru"
+
 	"github.com/jbenet/go-ipfs/blocks"
 	u "github.com/jbenet/go-ipfs/util"
 )
@@ -44,6 +46,10 @@ func (w *writecache) Put(b *blocks.Block) error {
 	return w.blockstore.Put(b)
 }
 
-func (w *writecache) AllKeys(offset int, limit int) ([]u.Key, error) {
-	return w.blockstore.AllKeys(offset, limit)
+func (w *writecache) AllKeys(ctx context.Context, offset int, limit int) ([]u.Key, error) {
+	return w.blockstore.AllKeys(ctx, offset, limit)
+}
+
+func (w *writecache) AllKeysChan(ctx context.Context, offset int, limit int) (<-chan u.Key, error) {
+	return w.blockstore.AllKeysChan(ctx, offset, limit)
 }

--- a/blocks/blockstore/write_cache_test.go
+++ b/blocks/blockstore/write_cache_test.go
@@ -84,7 +84,7 @@ func (c *callbackDatastore) Delete(key ds.Key) (err error) {
 	return c.ds.Delete(key)
 }
 
-func (c *callbackDatastore) Query(q dsq.Query) (*dsq.Results, error) {
+func (c *callbackDatastore) Query(q dsq.Query) (dsq.Results, error) {
 	c.f()
 	return c.ds.Query(q)
 }

--- a/blocks/blockstore/write_cache_test.go
+++ b/blocks/blockstore/write_cache_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	ds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
+	dsq "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
 	syncds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync"
 	"github.com/jbenet/go-ipfs/blocks"
 )
@@ -83,7 +84,7 @@ func (c *callbackDatastore) Delete(key ds.Key) (err error) {
 	return c.ds.Delete(key)
 }
 
-func (c *callbackDatastore) KeyList() ([]ds.Key, error) {
+func (c *callbackDatastore) Query(q dsq.Query) (*dsq.Results, error) {
 	c.f()
-	return c.ds.KeyList()
+	return c.ds.Query(q)
 }

--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -95,8 +95,8 @@ func (i Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	out, err := res.Reader()
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set(contentTypeHeader, "text/plain")
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
 	}

--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -114,6 +114,9 @@ func (i Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, isChan := res.Output().(chan interface{})
 	streamChans, _, _ := req.Option("stream-channels").Bool()
 	if isChan && streamChans {
+		// w.WriteString(transferEncodingHeader + ": chunked\r\n")
+		// w.Header().Set(channelHeader, "1")
+		// w.WriteHeader(200)
 		err = copyChunks(applicationJson, w, out)
 		if err != nil {
 			log.Error(err)

--- a/commands/request.go
+++ b/commands/request.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strconv"
 
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
+
 	"github.com/jbenet/go-ipfs/config"
 	"github.com/jbenet/go-ipfs/core"
 	u "github.com/jbenet/go-ipfs/util"
@@ -14,6 +16,10 @@ import (
 type optMap map[string]interface{}
 
 type Context struct {
+	// this Context is temporary. Will be replaced soon, as we get
+	// rid of this variable entirely.
+	Context context.Context
+
 	Online     bool
 	ConfigRoot string
 
@@ -267,7 +273,8 @@ func NewRequest(path []string, opts optMap, args []string, file File, cmd *Comma
 		optDefs = make(map[string]Option)
 	}
 
-	req := &request{path, opts, args, file, cmd, Context{}, optDefs}
+	ctx := Context{Context: context.TODO()}
+	req := &request{path, opts, args, file, cmd, ctx, optDefs}
 	err := req.ConvertOptions()
 	if err != nil {
 		return nil, err

--- a/core/commands/ping.go
+++ b/core/commands/ping.go
@@ -31,8 +31,9 @@ var PingCmd = &cmds.Command{
 Send pings to a peer using the routing system to discover its address
 		`,
 		ShortDescription: `
-		ipfs ping is a tool to find a node (in the routing system),
-		send pings, wait for pongs, and print out round-trip latency information.
+ipfs ping is a tool to test sending data to other nodes. It finds nodes
+via the routing system, send pings, wait for pongs, and print out round-
+trip latency information.
 		`,
 	},
 	Arguments: []cmds.Argument{

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -31,7 +31,7 @@ func KeyListTextMarshaler(res cmds.Response) (io.Reader, error) {
 
 var RefsCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
-		Tagline: "Lists link hashes from an object",
+		Tagline: "Lists links (references) from an object",
 		ShortDescription: `
 Retrieves the object named by <ipfs-path> and displays the link
 hashes it contains, with the following format:
@@ -41,7 +41,9 @@ hashes it contains, with the following format:
 Note: list all refs recursively with -r.
 `,
 	},
-
+	Subcommands: map[string]*cmds.Command{
+		"local": RefsLocalCmd,
+	},
 	Arguments: []cmds.Argument{
 		cmds.StringArg("ipfs-path", true, true, "Path to the object(s) to list refs from"),
 	},
@@ -102,6 +104,47 @@ Note: list all refs recursively with -r.
 				if _, err := rw.WriteRefs(o); err != nil {
 					log.Error(err)
 					eptr.SetError(err)
+					return
+				}
+			}
+		}()
+
+		return eptr, nil
+	},
+}
+
+var RefsLocalCmd = &cmds.Command{
+	Helptext: cmds.HelpText{
+		Tagline: "Lists all local references",
+		ShortDescription: `
+Displays the hashes of all local objects.
+`,
+	},
+
+	Run: func(req cmds.Request) (interface{}, error) {
+		n, err := req.Context().GetNode()
+		if err != nil {
+			return nil, err
+		}
+
+		// todo: make async
+		allKeys, err := n.Blockstore.AllKeys(0, 0)
+		if err != nil {
+			return nil, err
+		}
+
+		piper, pipew := io.Pipe()
+		eptr := &ErrPassThroughReader{R: piper}
+
+		go func() {
+			defer pipew.Close()
+
+			for _, k := range allKeys {
+				s := k.Pretty() + "\n"
+				if _, err := pipew.Write([]byte(s)); err != nil {
+					log.Error(err)
+					eptr.SetError(err)
+					return
 				}
 			}
 		}()

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -128,7 +128,7 @@ Displays the hashes of all local objects.
 		}
 
 		// todo: make async
-		allKeys, err := n.Blockstore.AllKeys(0, 0)
+		allKeys, err := n.Blockstore.AllKeys(context.TODO(), 0, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/util/datastore2/delayed.go
+++ b/util/datastore2/delayed.go
@@ -36,7 +36,7 @@ func (dds *delayed) Delete(key ds.Key) (err error) {
 	return dds.ds.Delete(key)
 }
 
-func (dds *delayed) Query(q dsq.Query) (*dsq.Results, error) {
+func (dds *delayed) Query(q dsq.Query) (dsq.Results, error) {
 	dds.delay.Wait()
 	return dds.ds.Query(q)
 }

--- a/util/datastore2/delayed.go
+++ b/util/datastore2/delayed.go
@@ -1,42 +1,44 @@
 package datastore2
 
 import (
-	datastore "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
+	ds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
+	dsq "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/query"
+
 	delay "github.com/jbenet/go-ipfs/util/delay"
 )
 
-func WithDelay(ds datastore.Datastore, delay delay.D) datastore.Datastore {
+func WithDelay(ds ds.Datastore, delay delay.D) ds.Datastore {
 	return &delayed{ds: ds, delay: delay}
 }
 
 type delayed struct {
-	ds    datastore.Datastore
+	ds    ds.Datastore
 	delay delay.D
 }
 
-func (dds *delayed) Put(key datastore.Key, value interface{}) (err error) {
+func (dds *delayed) Put(key ds.Key, value interface{}) (err error) {
 	dds.delay.Wait()
 	return dds.ds.Put(key, value)
 }
 
-func (dds *delayed) Get(key datastore.Key) (value interface{}, err error) {
+func (dds *delayed) Get(key ds.Key) (value interface{}, err error) {
 	dds.delay.Wait()
 	return dds.ds.Get(key)
 }
 
-func (dds *delayed) Has(key datastore.Key) (exists bool, err error) {
+func (dds *delayed) Has(key ds.Key) (exists bool, err error) {
 	dds.delay.Wait()
 	return dds.ds.Has(key)
 }
 
-func (dds *delayed) Delete(key datastore.Key) (err error) {
+func (dds *delayed) Delete(key ds.Key) (err error) {
 	dds.delay.Wait()
 	return dds.ds.Delete(key)
 }
 
-func (dds *delayed) KeyList() ([]datastore.Key, error) {
+func (dds *delayed) Query(q dsq.Query) (*dsq.Results, error) {
 	dds.delay.Wait()
-	return dds.ds.KeyList()
+	return dds.ds.Query(q)
 }
 
-var _ datastore.Datastore = &delayed{}
+var _ ds.Datastore = &delayed{}

--- a/util/key.go
+++ b/util/key.go
@@ -71,7 +71,7 @@ func (k *Key) Loggable() map[string]interface{} {
 
 // KeyFromDsKey returns a Datastore key
 func KeyFromDsKey(dsk ds.Key) Key {
-	return Key(dsk.BaseNamespace())
+	return Key(dsk.String()[1:])
 }
 
 // B58KeyConverter -- for KeyTransform datastores
@@ -131,3 +131,10 @@ func XOR(a, b []byte) []byte {
 	}
 	return c
 }
+
+// KeySlice is used for sorting Keys
+type KeySlice []Key
+
+func (es KeySlice) Len() int           { return len(es) }
+func (es KeySlice) Swap(i, j int)      { es[i], es[j] = es[j], es[i] }
+func (es KeySlice) Less(i, j int) bool { return es[i] < es[j] }


### PR DESCRIPTION
This command introduces datastore.Query and
ipfs refs local, which is a commant that simply
lists all refs stored locally.

HUGE WARNING: this commit changes how blocks are stored,
making all past blocks unlikely to be read. I am considering
putting in place an "upgrade" script to make sure everyone's
operation continues soundly. We'll need things like this in
place later on.