### PR TITLE
Gateway Server

### DIFF
--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -111,11 +111,14 @@ func daemonFunc(req cmds.Request) (interface{}, error) {
 		return nil, err
 	}
 
-	// ignore error for gateway address
-	// if there is an error (invalid address), then don't run the gateway
-	gatewayMaddr, _ := ma.NewMultiaddr(cfg.Addresses.Gateway)
-	if gatewayMaddr == nil {
-		fmt.Println("Invalid gateway address, not running gateway")
+	var gatewayMaddr ma.Multiaddr
+	if len(cfg.Addresses.Gateway) > 0 {
+		// ignore error for gateway address
+		// if there is an error (invalid address), then don't run the gateway
+		gatewayMaddr, _ = ma.NewMultiaddr(cfg.Addresses.Gateway)
+		if gatewayMaddr == nil {
+			log.Errorf("Invalid gateway address: %s", cfg.Addresses.Gateway)
+		}
 	}
 
 	// mount if the user provided the --mount flag

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -165,7 +165,9 @@ func listenAndServeAPI(node *core.IpfsNode, req cmds.Request, addr ma.Multiaddr)
 	cmdHandler := cmdsHttp.NewHandler(*req.Context(), commands.Root, origin)
 	mux.Handle(cmdsHttp.ApiPath+"/", cmdHandler)
 
-	ifpsHandler := &ipfsHandler{node}
+	ifpsHandler := &ipfsHandler{node: node}
+	ifpsHandler.LoadTemplate()
+
 	mux.Handle("/ipfs/", ifpsHandler)
 
 	// if the server exits beforehand

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -165,8 +165,10 @@ func listenAndServeAPI(node *core.IpfsNode, req cmds.Request, addr ma.Multiaddr)
 	cmdHandler := cmdsHttp.NewHandler(*req.Context(), commands.Root, origin)
 	mux.Handle(cmdsHttp.ApiPath+"/", cmdHandler)
 
-	ifpsHandler := &ipfsHandler{node: node}
-	ifpsHandler.LoadTemplate()
+	ifpsHandler, err := NewIpfsHandler(node)
+	if err != nil {
+		return err
+	}
 
 	mux.Handle("/ipfs/", ifpsHandler)
 
@@ -203,7 +205,10 @@ func listenAndServeGateway(node *core.IpfsNode, addr ma.Multiaddr) error {
 
 	server := manners.NewServer()
 	mux := http.NewServeMux()
-	ifpsHandler := &ipfsHandler{node}
+	ifpsHandler, err := NewIpfsHandler(node)
+	if err != nil {
+		return err
+	}
 	mux.Handle("/ipfs/", ifpsHandler)
 
 	done := make(chan struct{}, 1)

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -165,12 +165,12 @@ func listenAndServeAPI(node *core.IpfsNode, req cmds.Request, addr ma.Multiaddr)
 	cmdHandler := cmdsHttp.NewHandler(*req.Context(), commands.Root, origin)
 	mux.Handle(cmdsHttp.ApiPath+"/", cmdHandler)
 
-	ifpsHandler, err := NewIpfsHandler(node)
+	gateway, err := NewGatewayHandler(node)
 	if err != nil {
 		return err
 	}
 
-	mux.Handle("/ipfs/", ifpsHandler)
+	mux.Handle("/ipfs/", gateway)
 
 	// if the server exits beforehand
 	var serverError error
@@ -197,6 +197,7 @@ func listenAndServeAPI(node *core.IpfsNode, req cmds.Request, addr ma.Multiaddr)
 	return serverError
 }
 
+// the gateway also listens on its own address:port in addition to the API listener
 func listenAndServeGateway(node *core.IpfsNode, addr ma.Multiaddr) error {
 	_, host, err := manet.DialArgs(addr)
 	if err != nil {
@@ -205,11 +206,11 @@ func listenAndServeGateway(node *core.IpfsNode, addr ma.Multiaddr) error {
 
 	server := manners.NewServer()
 	mux := http.NewServeMux()
-	ifpsHandler, err := NewIpfsHandler(node)
+	gateway, err := NewGatewayHandler(node)
 	if err != nil {
 		return err
 	}
-	mux.Handle("/ipfs/", ifpsHandler)
+	mux.Handle("/ipfs/", gateway)
 
 	done := make(chan struct{}, 1)
 	defer func() {

--- a/cmd/ipfs/daemon.go
+++ b/cmd/ipfs/daemon.go
@@ -24,7 +24,10 @@ const (
 	ipnsMountKwd  = "mount-ipns"
 	// apiAddrKwd    = "address-api"
 	// swarmAddrKwd  = "address-swarm"
+
 	originEnvKey = "API_ORIGIN"
+
+	webuiPath = "/ipfs/QmTWvqK9dYvqjAMAcCeUun8b45Fwu7wPhEN9B9TsGbkXfJ"
 )
 
 var daemonCmd = &cmds.Command{
@@ -171,6 +174,7 @@ func listenAndServeAPI(node *core.IpfsNode, req cmds.Request, addr ma.Multiaddr)
 	}
 
 	mux.Handle("/ipfs/", gateway)
+	mux.Handle("/webui/", &redirectHandler{webuiPath})
 
 	// if the server exits beforehand
 	var serverError error
@@ -237,4 +241,12 @@ func listenAndServeGateway(node *core.IpfsNode, addr ma.Multiaddr) error {
 	}()
 
 	return nil
+}
+
+type redirectHandler struct {
+	path string
+}
+
+func (i *redirectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, i.path, 302)
 }

--- a/cmd/ipfs/gatewayHandler.go
+++ b/cmd/ipfs/gatewayHandler.go
@@ -3,7 +3,9 @@ package main
 import (
 	"html/template"
 	"io"
+	"mime"
 	"net/http"
+	"strings"
 
 	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
 	mh "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
@@ -94,6 +96,15 @@ func (i *gatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Error(err)
 		w.Write([]byte(err.Error()))
 		return
+	}
+
+	extensionIndex := strings.LastIndex(path, ".")
+	if extensionIndex != -1 {
+		extension := path[extensionIndex:]
+		mimeType := mime.TypeByExtension(extension)
+		if len(mimeType) > 0 {
+			w.Header().Add("Content-Type", mimeType)
+		}
 	}
 
 	dr, err := i.NewDagReader(nd)

--- a/cmd/ipfs/ipfsHandler.go
+++ b/cmd/ipfs/ipfsHandler.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"html/template"
 	"io"
 	"net/http"
 
@@ -23,10 +24,29 @@ type ipfs interface {
 	NewDagReader(nd *dag.Node) (io.Reader, error)
 }
 
+// shortcut for templating
+type H map[string]interface{}
+
+// struct for directory listing
+type directoryItem struct {
+	Size uint64
+	Name string
+}
+
 // ipfsHandler is a HTTP handler that serves IPFS objects (accessible by default at /ipfs/<path>)
 // (it serves requests like GET /ipfs/QmVRzPKPzNtSrEzBFm2UZfxmPAgnaLke4DMcerbsGGSaFe/link)
 type ipfsHandler struct {
-	node *core.IpfsNode
+	node    *core.IpfsNode
+	dirList *template.Template
+}
+
+// Load the directroy list template
+func (i *ipfsHandler) LoadTemplate() {
+	t, err := template.New("dir").Parse(listingTemplate)
+	if err != nil {
+		log.Error(err)
+	}
+	i.dirList = t
 }
 
 func (i *ipfsHandler) ResolvePath(path string) (*dag.Node, error) {
@@ -65,14 +85,63 @@ func (i *ipfsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	dr, err := i.NewDagReader(nd)
+
 	if err != nil {
-		// TODO: return json object containing the tree data if it's a directory (err == ErrIsDir)
+		if err == uio.ErrIsDir {
+			log.Debug("is directory %s", path)
+
+			if path[len(path)-1:] != "/" {
+				log.Debug("missing trailing slash redirect")
+				http.Redirect(w, r, "/ipfs/"+path+"/", 307)
+				return
+			}
+
+			// storage for directory listing
+			var dirListing []directoryItem
+			// loop through files
+			for _, link := range nd.Links {
+				if link.Name == "index.html" {
+					log.Debug("found index")
+					// return index page
+					nd, err := i.ResolvePath(path + "/index.html")
+					if err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						w.Write([]byte(err.Error()))
+						log.Error("%s", err)
+						return
+					}
+					dr, err := i.NewDagReader(nd)
+					if err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						w.Write([]byte(err.Error()))
+						log.Error("%s", err)
+						return
+					}
+					// write to request
+					io.Copy(w, dr)
+					return
+				}
+				dirListing = append(dirListing, directoryItem{link.Size, link.Name})
+			}
+			// template and return directory listing
+			//for i, j := range dirListing {
+			//	log.Debug(i, ":", j.Size, " ", j.Name)
+			//}
+			err := i.dirList.Execute(w, H{"listing": dirListing, "path": path})
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(err.Error()))
+				log.Error("%s", err)
+				return
+			}
+			return
+		}
 		w.WriteHeader(http.StatusInternalServerError)
 		log.Error(err)
 		w.Write([]byte(err.Error()))
 		return
 	}
-
+	// data file
 	io.Copy(w, dr)
 }
 
@@ -97,3 +166,23 @@ func (i *ipfsHandler) postHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 	w.Write([]byte(mh.Multihash(k).B58String()))
 }
+
+// Directory listing template
+var listingTemplate = `
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<title>{{ .path }}</title>
+	</head>
+	<body>
+	<h2>Index of {{ .path }}</h2>
+	<ul>
+	<li> <a href="./..">Parent</a></li>	
+    {{ range $item := .listing }}
+	 <li> <a href="./{{ $item.Name }}">{{ $item.Name }}</a> - {{ $item.Size }} bytes</li>	
+	{{ end }}
+	</ul>
+	</body>
+</html>
+`

--- a/cmd/ipfs/ipfsHandler.go
+++ b/cmd/ipfs/ipfsHandler.go
@@ -25,7 +25,7 @@ type ipfs interface {
 }
 
 // shortcut for templating
-type H map[string]interface{}
+type webHandler map[string]interface{}
 
 // struct for directory listing
 type directoryItem struct {
@@ -91,7 +91,7 @@ func (i *ipfsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log.Debug("is directory %s", path)
 
 			if path[len(path)-1:] != "/" {
-				log.Debug("missing trailing slash redirect")
+				log.Debug("missing trailing slash, redirect")
 				http.Redirect(w, r, "/ipfs/"+path+"/", 307)
 				return
 			}
@@ -105,16 +105,12 @@ func (i *ipfsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					// return index page
 					nd, err := i.ResolvePath(path + "/index.html")
 					if err != nil {
-						w.WriteHeader(http.StatusInternalServerError)
-						w.Write([]byte(err.Error()))
-						log.Error("%s", err)
+						internalWebError(w, err)
 						return
 					}
 					dr, err := i.NewDagReader(nd)
 					if err != nil {
-						w.WriteHeader(http.StatusInternalServerError)
-						w.Write([]byte(err.Error()))
-						log.Error("%s", err)
+						internalWebError(w, err)
 						return
 					}
 					// write to request
@@ -124,24 +120,18 @@ func (i *ipfsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				dirListing = append(dirListing, directoryItem{link.Size, link.Name})
 			}
 			// template and return directory listing
-			//for i, j := range dirListing {
-			//	log.Debug(i, ":", j.Size, " ", j.Name)
-			//}
-			err := i.dirList.Execute(w, H{"listing": dirListing, "path": path})
+			err := i.dirList.Execute(w, webHandler{"listing": dirListing, "path": path})
 			if err != nil {
-				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(err.Error()))
-				log.Error("%s", err)
+				internalWebError(w, err)
 				return
 			}
 			return
 		}
-		w.WriteHeader(http.StatusInternalServerError)
-		log.Error(err)
-		w.Write([]byte(err.Error()))
+		// not a directory and still an error
+		internalWebError(w, err)
 		return
 	}
-	// data file
+	// return data file
 	io.Copy(w, dr)
 }
 
@@ -165,6 +155,13 @@ func (i *ipfsHandler) postHandler(w http.ResponseWriter, r *http.Request) {
 	//TODO: return json representation of list instead
 	w.WriteHeader(http.StatusCreated)
 	w.Write([]byte(mh.Multihash(k).B58String()))
+}
+
+// return a 500 error and log
+func internalWebError(w http.ResponseWriter, err error) {
+	w.WriteHeader(http.StatusInternalServerError)
+	w.Write([]byte(err.Error()))
+	log.Error("%s", err)
 }
 
 // Directory listing template

--- a/cmd/ipfs/ipfsHandler.go
+++ b/cmd/ipfs/ipfsHandler.go
@@ -40,13 +40,25 @@ type ipfsHandler struct {
 	dirList *template.Template
 }
 
+func NewIpfsHandler(node *core.IpfsNode) (*ipfsHandler, error) {
+	i := &ipfsHandler{
+		node: node,
+	}
+	err := i.loadTemplate()
+	if err != nil {
+		return nil, err
+	}
+	return i, nil
+}
+
 // Load the directroy list template
-func (i *ipfsHandler) LoadTemplate() {
+func (i *ipfsHandler) loadTemplate() error {
 	t, err := template.New("dir").Parse(listingTemplate)
 	if err != nil {
-		log.Error(err)
+		return err
 	}
 	i.dirList = t
+	return nil
 }
 
 func (i *ipfsHandler) ResolvePath(path string) (*dag.Node, error) {
@@ -175,9 +187,9 @@ var listingTemplate = `
 	<body>
 	<h2>Index of {{ .path }}</h2>
 	<ul>
-	<li> <a href="./..">Parent</a></li>	
-    {{ range $item := .listing }}
-	 <li> <a href="./{{ $item.Name }}">{{ $item.Name }}</a> - {{ $item.Size }} bytes</li>	
+	<li><a href="./..">..</a></li>	
+  {{ range $item := .listing }}
+	<li><a href="./{{ $item.Name }}">{{ $item.Name }}</a> - {{ $item.Size }} bytes</li>	
 	{{ end }}
 	</ul>
 	</body>

--- a/config/config.go
+++ b/config/config.go
@@ -40,8 +40,9 @@ type Datastore struct {
 
 // Addresses stores the (string) multiaddr addresses for the node.
 type Addresses struct {
-	Swarm []string // addresses for the swarm network
-	API   string   // address for the local API (RPC)
+	Swarm   []string // addresses for the swarm network
+	API     string   // address for the local API (RPC)
+	Gateway string   // address to listen on for IPFS HTTP object gateway
 }
 
 // Mounts stores the (string) mount points

--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -88,7 +88,7 @@ test_launch_ipfs_daemon() {
 
 	test_expect_success FUSE "'ipfs daemon' output looks good" '
 		IPFS_PID=$! &&
-		echo "daemon listening on /ip4/127.0.0.1/tcp/5001" >expected &&
+		echo "API server listening on /ip4/127.0.0.1/tcp/5001" >expected &&
 		test_cmp_repeat_10_sec expected actual ||
 		fsh cat daemon_err
 	'


### PR DESCRIPTION
This PR adds a second HTTP server that serves IPFS objects, without giving access to the command API (so that it can be used for public services, like ipfs.io). It is off by default, but will listen when there is an address specified at the `Addresses.Gateway` key in the config.

This also fixes MIME type handling in the gateway so that web apps will be function correctly when served from the gateway or API server.

@zignig's directory listing changes were included. 

 A redirect was added from `/webui` on the API server to the hash of the webui app root. In the future, we can change the hash to an IPNS path, and update the webui by publishing to that IPNS name.