### PR TITLE
Stdin Input

### DIFF
--- a/commands/cli/parse.go
+++ b/commands/cli/parse.go
@@ -260,7 +260,8 @@ func appendStdinAsString(args []string, stdin *os.File) ([]string, *os.File, err
 		return nil, nil, err
 	}
 
-	return append(args, buf.String()), nil, nil
+	input := strings.TrimSpace(buf.String())
+	return append(args, strings.Split(input, "\n")...), nil, nil
 }
 
 func appendFile(args []cmds.File, inputs []string, argDef *cmds.Argument, recursive bool) ([]cmds.File, []string, error) {

--- a/core/commands/add.go
+++ b/core/commands/add.go
@@ -37,7 +37,7 @@ remains to be implemented.
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.FileArg("path", true, true, "The path to a file to be added to IPFS").EnableRecursive(),
+		cmds.FileArg("path", true, true, "The path to a file to be added to IPFS").EnableRecursive().EnableStdin(),
 	},
 	Options: []cmds.Option{
 		cmds.OptionRecursivePath, // a builtin option that allows recursive paths (-r, --recursive)

--- a/core/commands/block.go
+++ b/core/commands/block.go
@@ -55,7 +55,7 @@ on raw ipfs blocks. It outputs the following to stdout:
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("key", true, false, "The base58 multihash of an existing block to get"),
+		cmds.StringArg("key", true, false, "The base58 multihash of an existing block to get").EnableStdin(),
 	},
 	Run: func(req cmds.Request) (interface{}, error) {
 		b, err := getBlockForKey(req, req.Arguments()[0])
@@ -87,7 +87,7 @@ It outputs to stdout, and <key> is a base58 encoded multihash.
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("key", true, false, "The base58 multihash of an existing block to get"),
+		cmds.StringArg("key", true, false, "The base58 multihash of an existing block to get").EnableStdin(),
 	},
 	Run: func(req cmds.Request) (interface{}, error) {
 		b, err := getBlockForKey(req, req.Arguments()[0])

--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -18,7 +18,7 @@ it contains.
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("ipfs-path", true, true, "The path to the IPFS object(s) to be outputted"),
+		cmds.StringArg("ipfs-path", true, true, "The path to the IPFS object(s) to be outputted").EnableStdin(),
 	},
 	Run: func(req cmds.Request) (interface{}, error) {
 		node, err := req.Context().GetNode()

--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -43,7 +43,7 @@ if no peer is specified, prints out local peers info.
 `,
 	},
 	Arguments: []cmds.Argument{
-		cmds.StringArg("peerid", false, false, "peer.ID of node to look up"),
+		cmds.StringArg("peerid", false, false, "peer.ID of node to look up").EnableStdin(),
 	},
 	Run: func(req cmds.Request) (interface{}, error) {
 		node, err := req.Context().GetNode()

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -35,7 +35,7 @@ it contains, with the following format:
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("ipfs-path", true, true, "The path to the IPFS object(s) to list links from"),
+		cmds.StringArg("ipfs-path", true, true, "The path to the IPFS object(s) to list links from").EnableStdin(),
 	},
 	Run: func(req cmds.Request) (interface{}, error) {
 		node, err := req.Context().GetNode()

--- a/core/commands/object.go
+++ b/core/commands/object.go
@@ -69,7 +69,7 @@ output is the raw data of the object.
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("key", true, false, "Key of the object to retrieve, in base58-encoded multihash format"),
+		cmds.StringArg("key", true, false, "Key of the object to retrieve, in base58-encoded multihash format").EnableStdin(),
 	},
 	Run: func(req cmds.Request) (interface{}, error) {
 		n, err := req.Context().GetNode()
@@ -93,7 +93,7 @@ multihash.
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("key", true, false, "Key of the object to retrieve, in base58-encoded multihash format"),
+		cmds.StringArg("key", true, false, "Key of the object to retrieve, in base58-encoded multihash format").EnableStdin(),
 	},
 	Run: func(req cmds.Request) (interface{}, error) {
 		n, err := req.Context().GetNode()
@@ -135,7 +135,7 @@ This command outputs data in the following encodings:
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("key", true, false, "Key of the object to retrieve (in base58-encoded multihash format)"),
+		cmds.StringArg("key", true, false, "Key of the object to retrieve (in base58-encoded multihash format)").EnableStdin(),
 	},
 	Run: func(req cmds.Request) (interface{}, error) {
 		n, err := req.Context().GetNode()
@@ -199,7 +199,7 @@ var objectStatCmd = &cmds.Command{
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("key", true, false, "Key of the object to retrieve (in base58-encoded multihash format)"),
+		cmds.StringArg("key", true, false, "Key of the object to retrieve (in base58-encoded multihash format)").EnableStdin(),
 	},
 	Run: func(req cmds.Request) (interface{}, error) {
 		n, err := req.Context().GetNode()

--- a/core/commands/pin.go
+++ b/core/commands/pin.go
@@ -31,7 +31,7 @@ on disk.
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("ipfs-path", true, true, "Path to object(s) to be pinned"),
+		cmds.StringArg("ipfs-path", true, true, "Path to object(s) to be pinned").EnableStdin(),
 	},
 	Options: []cmds.Option{
 		cmds.BoolOption("recursive", "r", "Recursively pin the object linked to by the specified object(s)"),
@@ -71,7 +71,7 @@ collected if needed.
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("ipfs-path", true, true, "Path to object(s) to be unpinned"),
+		cmds.StringArg("ipfs-path", true, true, "Path to object(s) to be unpinned").EnableStdin(),
 	},
 	Options: []cmds.Option{
 		cmds.BoolOption("recursive", "r", "Recursively unpin the object linked to by the specified object(s)"),

--- a/core/commands/ping.go
+++ b/core/commands/ping.go
@@ -37,7 +37,7 @@ trip latency information.
 		`,
 	},
 	Arguments: []cmds.Argument{
-		cmds.StringArg("peer ID", true, true, "ID of peer to be pinged"),
+		cmds.StringArg("peer ID", true, true, "ID of peer to be pinged").EnableStdin(),
 	},
 	Options: []cmds.Option{
 		cmds.IntOption("count", "n", "number of ping messages to send"),

--- a/core/commands/publish.go
+++ b/core/commands/publish.go
@@ -44,7 +44,7 @@ Publish a <ref> to another public key:
 
 	Arguments: []cmds.Argument{
 		cmds.StringArg("name", false, false, "The IPNS name to publish to. Defaults to your node's peerID"),
-		cmds.StringArg("ipfs-path", true, false, "IPFS path of the obejct to be published at <name>"),
+		cmds.StringArg("ipfs-path", true, false, "IPFS path of the obejct to be published at <name>").EnableStdin(),
 	},
 	Run: func(req cmds.Request) (interface{}, error) {
 		log.Debug("Begin Publish")

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -45,7 +45,7 @@ Note: list all refs recursively with -r.
 		"local": RefsLocalCmd,
 	},
 	Arguments: []cmds.Argument{
-		cmds.StringArg("ipfs-path", true, true, "Path to the object(s) to list refs from"),
+		cmds.StringArg("ipfs-path", true, true, "Path to the object(s) to list refs from").EnableStdin(),
 	},
 	Options: []cmds.Option{
 		cmds.StringOption("format", "Emit edges with given format. tokens: <src> <dst> <linkname>"),

--- a/core/commands/resolve.go
+++ b/core/commands/resolve.go
@@ -38,7 +38,7 @@ Resolve te value of another name:
 	},
 
 	Arguments: []cmds.Argument{
-		cmds.StringArg("name", false, false, "The IPNS name to resolve. Defaults to your node's peerID."),
+		cmds.StringArg("name", false, false, "The IPNS name to resolve. Defaults to your node's peerID.").EnableStdin(),
 	},
 	Run: func(req cmds.Request) (interface{}, error) {
 

--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -83,7 +83,7 @@ ipfs swarm connect /ip4/104.131.131.82/tcp/4001/QmaCpDMGvV2BGHeYERUEnRQAwe3N8Szb
 `,
 	},
 	Arguments: []cmds.Argument{
-		cmds.StringArg("address", true, true, "address of peer to connect to"),
+		cmds.StringArg("address", true, true, "address of peer to connect to").EnableStdin(),
 	},
 	Run: func(req cmds.Request) (interface{}, error) {
 		ctx := context.TODO()


### PR DESCRIPTION
This PR enables stdin input for `add` and `cat`. Also, the CLI parser now splits lines into multiple arguments for  stdin string arguments.

Now you can do some cool things, like:

* `echo "hello, world" | ipfs add`
* `ipfs refs <some object> | ipfs cat`
* `ipfs add <some file> -q | ipfs cat`

It seems like we really might want to just enable stdin for any argument, should we go through and turn it on for everything where it makes sense, or should we make arguments use it by default? It would be cool to be able to `ipfs add <file> -q | ipfs object get`, or even `ipfs bootstrap list | ipfs swarm connect`. 