### PR TITLE
fix: privatize Mux fields

### DIFF
--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -16,7 +16,7 @@ var log = eventlog.Logger("p2p/host/basic")
 
 type BasicHost struct {
 	network inet.Network
-	mux     protocol.Mux
+	mux     *protocol.Mux
 	ids     *identify.IDService
 	relay   *relay.RelayService
 }
@@ -25,7 +25,7 @@ type BasicHost struct {
 func New(net inet.Network) *BasicHost {
 	h := &BasicHost{
 		network: net,
-		mux:     protocol.Mux{Handlers: protocol.StreamHandlerMap{}},
+		mux:     protocol.NewMux(),
 	}
 
 	// setup host services
@@ -65,7 +65,7 @@ func (h *BasicHost) Network() inet.Network {
 
 // Mux returns the Mux multiplexing incoming streams to protocol handlers
 func (h *BasicHost) Mux() *protocol.Mux {
-	return &h.mux
+	return h.mux
 }
 
 func (h *BasicHost) IDService() *identify.IDService {

--- a/p2p/protocol/mux_test.go
+++ b/p2p/protocol/mux_test.go
@@ -38,12 +38,12 @@ func TestHandler(t *testing.T) {
 		}
 	}
 
-	m := Mux{Handlers: StreamHandlerMap{}}
+	m := NewMux()
 	m.Default = h("default")
-	m.Handlers["/dht"] = h("bitswap")
+	m.SetHandler("/dht", h("bitswap"))
 	// m.Handlers["/ipfs"] = h("bitswap") // default!
-	m.Handlers["/bitswap"] = h("bitswap")
-	m.Handlers["/ipfs/dksnafkasnfkdajfkdajfdsjadosiaaodj"] = h("bitswap")
+	m.SetHandler("/bitswap", h("bitswap"))
+	m.SetHandler("/ipfs/dksnafkasnfkdajfkdajfdsjadosiaaodj", h("bitswap"))
 
 	for k, v := range testCases {
 		var buf bytes.Buffer

--- a/p2p/protocol/mux_test.go
+++ b/p2p/protocol/mux_test.go
@@ -39,7 +39,7 @@ func TestHandler(t *testing.T) {
 	}
 
 	m := NewMux()
-	m.Default = h("default")
+	m.SetDefaultHandler(h("default"))
 	m.SetHandler("/dht", h("bitswap"))
 	// m.Handlers["/ipfs"] = h("bitswap") // default!
 	m.SetHandler("/bitswap", h("bitswap"))


### PR DESCRIPTION
lock is made private so outsiders cannot lock the mux.
handlers made private to force outsiders to use accessors.