### PR TITLE
p2p/net/swarm: fix connect self problems

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -359,7 +359,7 @@ func constructPeerHost(ctx context.Context, ctxg ctxgroup.ContextGroup, cfg *con
 
 	// make sure we error out if our config does not have addresses we can use
 	log.Debugf("Config.Addresses.Swarm:%s", listenAddrs)
-	filteredAddrs := addrutil.FilterAddrs(listenAddrs)
+	filteredAddrs := addrutil.FilterUsableAddrs(listenAddrs)
 	log.Debugf("Config.Addresses.Swarm:%s (filtered)", listenAddrs)
 	if len(filteredAddrs) < 1 {
 		return nil, debugerror.Errorf("addresses in config not usable: %s", listenAddrs)

--- a/p2p/net/swarm/addr/addr_test.go
+++ b/p2p/net/swarm/addr/addr_test.go
@@ -53,9 +53,9 @@ func TestFilterAddrs(t *testing.T) {
 		}
 	}
 
-	subtestAddrsEqual(t, FilterAddrs(bad), []ma.Multiaddr{})
-	subtestAddrsEqual(t, FilterAddrs(good), good)
-	subtestAddrsEqual(t, FilterAddrs(goodAndBad), good)
+	subtestAddrsEqual(t, FilterUsableAddrs(bad), []ma.Multiaddr{})
+	subtestAddrsEqual(t, FilterUsableAddrs(good), good)
+	subtestAddrsEqual(t, FilterUsableAddrs(goodAndBad), good)
 }
 
 func subtestAddrsEqual(t *testing.T, a, b []ma.Multiaddr) {
@@ -194,5 +194,39 @@ func TestWANShareable(t *testing.T) {
 	wanbad2 := WANShareableAddrs(wanbad)
 	if len(wanbad2) != 0 {
 		t.Error("should be zero")
+	}
+}
+
+func TestSubtract(t *testing.T) {
+
+	a := []ma.Multiaddr{
+		newMultiaddr(t, "/ip4/127.0.0.1/tcp/1234"),
+		newMultiaddr(t, "/ip4/0.0.0.0/tcp/1234"),
+		newMultiaddr(t, "/ip6/::1/tcp/1234"),
+		newMultiaddr(t, "/ip6/::/tcp/1234"),
+		newMultiaddr(t, "/ip6/fe80::1/tcp/1234"),
+		newMultiaddr(t, "/ip6/fe80::/tcp/1234"),
+	}
+
+	b := []ma.Multiaddr{
+		newMultiaddr(t, "/ip4/127.0.0.1/tcp/1234"),
+		newMultiaddr(t, "/ip6/::1/tcp/1234"),
+		newMultiaddr(t, "/ip6/fe80::1/tcp/1234"),
+	}
+
+	c1 := []ma.Multiaddr{
+		newMultiaddr(t, "/ip4/0.0.0.0/tcp/1234"),
+		newMultiaddr(t, "/ip6/::/tcp/1234"),
+		newMultiaddr(t, "/ip6/fe80::/tcp/1234"),
+	}
+
+	c2 := Subtract(a, b)
+	if len(c1) != len(c2) {
+		t.Error("should be the same")
+	}
+	for i, ca := range c1 {
+		if !c2[i].Equal(ca) {
+			t.Error("should be the same", ca, c2[i])
+		}
 	}
 }

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -41,7 +41,7 @@ func NewSwarm(ctx context.Context, listenAddrs []ma.Multiaddr,
 	local peer.ID, peers peer.Peerstore) (*Swarm, error) {
 
 	if len(listenAddrs) > 0 {
-		filtered := addrutil.FilterAddrs(listenAddrs)
+		filtered := addrutil.FilterUsableAddrs(listenAddrs)
 		if len(filtered) < 1 {
 			return nil, fmt.Errorf("swarm cannot use any addr in: %s", listenAddrs)
 		}

--- a/p2p/net/swarm/swarm_addr_test.go
+++ b/p2p/net/swarm/swarm_addr_test.go
@@ -51,9 +51,9 @@ func TestFilterAddrs(t *testing.T) {
 		}
 	}
 
-	subtestAddrsEqual(t, addrutil.FilterAddrs(bad), []ma.Multiaddr{})
-	subtestAddrsEqual(t, addrutil.FilterAddrs(good), good)
-	subtestAddrsEqual(t, addrutil.FilterAddrs(goodAndBad), good)
+	subtestAddrsEqual(t, addrutil.FilterUsableAddrs(bad), []ma.Multiaddr{})
+	subtestAddrsEqual(t, addrutil.FilterUsableAddrs(good), good)
+	subtestAddrsEqual(t, addrutil.FilterUsableAddrs(goodAndBad), good)
 
 	// now test it with swarm
 

--- a/p2p/net/swarm/swarm_dial.go
+++ b/p2p/net/swarm/swarm_dial.go
@@ -41,7 +41,7 @@ func (s *Swarm) Dial(ctx context.Context, p peer.ID) (*Conn, error) {
 
 	remoteAddrs := s.peers.Addresses(p)
 	// make sure we can use the addresses.
-	remoteAddrs = addrutil.FilterAddrs(remoteAddrs)
+	remoteAddrs = addrutil.FilterUsableAddrs(remoteAddrs)
 	if len(remoteAddrs) == 0 {
 		return nil, errors.New("peer has no addresses")
 	}


### PR DESCRIPTION
This adds two checks after a successful conn.Dial
* if the remote peer is not who we wanted, close conn
* if the remove peer is outselves, close conn

(the second is redundant, but the codebase may evolve to end up disabling the
first check, so keeping the second in place helps)

note: Loopback addresses are actually sent out (they _have to be_, in cases
where there are >1 node in the same machine), so many times when trying
connections, nodes end up dialing themselves.