### PR TITLE
testutil ci pkgs check env vars

### DIFF
--- a/fuse/ipns/ipns_test.go
+++ b/fuse/ipns/ipns_test.go
@@ -5,24 +5,20 @@ import (
 	"crypto/rand"
 	"io/ioutil"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
 	fstest "github.com/jbenet/go-ipfs/Godeps/_workspace/src/bazil.org/fuse/fs/fstestutil"
+
 	core "github.com/jbenet/go-ipfs/core"
 	u "github.com/jbenet/go-ipfs/util"
+	ci "github.com/jbenet/go-ipfs/util/testutil/ci"
 )
 
-func maybeSkipFuseTests(t *testing.T) bool {
-	v := "TEST_NO_FUSE"
-	n := strings.ToLower(os.Getenv(v))
-	skip := n != "" && n != "false" && n != "f"
-
-	if skip {
-		t.Skipf("Skipping FUSE tests (%s=%s)", v, n)
+func maybeSkipFuseTests(t *testing.T) {
+	if ci.NoFuse() {
+		t.Skip("Skipping FUSE tests")
 	}
-	return skip
 }
 
 func randBytes(size int) []byte {

--- a/p2p/net/conn/conn_test.go
+++ b/p2p/net/conn/conn_test.go
@@ -3,13 +3,14 @@ package conn
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"runtime"
 	"sync"
 	"testing"
 	"time"
 
 	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
+
+	travis "github.com/jbenet/go-ipfs/util/testutil/ci/travis"
 )
 
 func testOneSendRecv(t *testing.T, c1, c2 Conn) {
@@ -62,7 +63,7 @@ func TestCloseLeak(t *testing.T) {
 		t.SkipNow()
 	}
 
-	if os.Getenv("TRAVIS") == "true" {
+	if travis.IsRunning() {
 		t.Skip("this doesn't work well on travis")
 	}
 

--- a/p2p/net/conn/secure_conn_test.go
+++ b/p2p/net/conn/secure_conn_test.go
@@ -2,13 +2,13 @@ package conn
 
 import (
 	"bytes"
-	"os"
 	"runtime"
 	"sync"
 	"testing"
 	"time"
 
 	ic "github.com/jbenet/go-ipfs/p2p/crypto"
+	travis "github.com/jbenet/go-ipfs/util/testutil/ci/travis"
 
 	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
 )
@@ -131,7 +131,7 @@ func TestSecureCloseLeak(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	if os.Getenv("TRAVIS") == "true" {
+	if travis.IsRunning() {
 		t.Skip("this doesn't work well on travis")
 	}
 

--- a/p2p/net/swarm/dial_test.go
+++ b/p2p/net/swarm/dial_test.go
@@ -2,14 +2,16 @@ package swarm
 
 import (
 	"net"
-	"os"
 	"sync"
 	"testing"
 	"time"
 
 	addrutil "github.com/jbenet/go-ipfs/p2p/net/swarm/addr"
 	peer "github.com/jbenet/go-ipfs/p2p/peer"
+
 	testutil "github.com/jbenet/go-ipfs/util/testutil"
+	jenkins "github.com/jbenet/go-ipfs/util/testutil/ci/jenkins"
+	travis "github.com/jbenet/go-ipfs/util/testutil/ci/travis"
 
 	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
 	ma "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
@@ -114,7 +116,7 @@ func TestDialWait(t *testing.T) {
 	defer s1.Close()
 
 	s1.dialT = time.Millisecond * 300 // lower timeout for tests.
-	if os.Getenv("TRAVIS") == "true" {
+	if travis.IsRunning() {
 		s1.dialT = time.Second
 	}
 
@@ -148,8 +150,8 @@ func TestDialWait(t *testing.T) {
 
 func TestDialBackoff(t *testing.T) {
 	// t.Skip("skipping for another test")
-	if os.Getenv("TRAVIS") == "true" {
-		t.Skip("travis will never have fun with this test")
+	if travis.IsRunning() || jenkins.IsRunning() {
+		t.Skip("travis and jenkins will never have fun with this test")
 	}
 
 	t.Parallel()
@@ -375,7 +377,7 @@ func TestDialBackoffClears(t *testing.T) {
 	defer s2.Close()
 	s1.dialT = time.Millisecond * 300 // lower timeout for tests.
 	s2.dialT = time.Millisecond * 300 // lower timeout for tests.
-	if os.Getenv("TRAVIS") == "true" {
+	if travis.IsRunning() {
 		s1.dialT = time.Second
 		s2.dialT = time.Second
 	}

--- a/util/ctx/fracctx_test.go
+++ b/util/ctx/fracctx_test.go
@@ -1,16 +1,17 @@
 package ctxutil
 
 import (
-	"os"
 	"testing"
 	"time"
+
+	travis "github.com/jbenet/go-ipfs/util/testutil/ci/travis"
 
 	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
 )
 
 // this test is on the context tool itself, not our stuff. it's for sanity on ours.
 func TestDeadline(t *testing.T) {
-	if os.Getenv("TRAVIS") == "true" {
+	if travis.IsRunning() {
 		t.Skip("timeouts don't work reliably on travis")
 	}
 
@@ -42,7 +43,7 @@ func TestDeadlineFractionForever(t *testing.T) {
 }
 
 func TestDeadlineFractionHalf(t *testing.T) {
-	if os.Getenv("TRAVIS") == "true" {
+	if travis.IsRunning() {
 		t.Skip("timeouts don't work reliably on travis")
 	}
 

--- a/util/testutil/ci/ci.go
+++ b/util/testutil/ci/ci.go
@@ -42,11 +42,11 @@ func Env(v EnvVar) string {
 }
 
 // Returns whether FUSE is explicitly disabled wiht TEST_NO_FUSE.
-func NoFuse(v EnvVar) bool {
+func NoFuse() bool {
 	return os.Getenv(string(VarNoFuse)) == "1"
 }
 
 // Returns whether TEST_VERBOSE is enabled.
-func Verbose(v EnvVar) bool {
+func Verbose() bool {
 	return os.Getenv(string(VarVerbose)) == "1"
 }

--- a/util/testutil/ci/ci.go
+++ b/util/testutil/ci/ci.go
@@ -1,0 +1,52 @@
+// Package ci implements some helper functions to use during
+// tests. Many times certain facilities are not available, or tests
+// must run differently.
+package ci
+
+import (
+	"os"
+
+	jenkins "github.com/jbenet/go-ipfs/util/testutil/ci/jenkins"
+	travis "github.com/jbenet/go-ipfs/util/testutil/ci/travis"
+)
+
+// EnvVar is a type to use travis-only env var names with
+// the type system.
+type EnvVar string
+
+// Environment variables that TravisCI uses.
+const (
+	VarCI      EnvVar = "TEST_NO_FUSE"
+	VarNoFuse  EnvVar = "TEST_NO_FUSE"
+	VarVerbose EnvVar = "TEST_VERBOSE"
+)
+
+// IsRunning attempts to determine whether this process is
+// running on CI. This is done by checking any of:
+//
+//  CI=true
+//  travis.IsRunning()
+//  jenkins.IsRunning()
+//
+func IsRunning() bool {
+	if os.Getenv(string(VarCI)) == "true" {
+		return true
+	}
+
+	return travis.IsRunning() || jenkins.IsRunning()
+}
+
+// Env returns the value of a CI env variable.
+func Env(v EnvVar) string {
+	return os.Getenv(string(v))
+}
+
+// Returns whether FUSE is explicitly disabled wiht TEST_NO_FUSE.
+func NoFuse(v EnvVar) bool {
+	return os.Getenv(string(VarNoFuse)) == "1"
+}
+
+// Returns whether TEST_VERBOSE is enabled.
+func Verbose(v EnvVar) bool {
+	return os.Getenv(string(VarVerbose)) == "1"
+}

--- a/util/testutil/ci/jenkins/jenkins.go
+++ b/util/testutil/ci/jenkins/jenkins.go
@@ -12,7 +12,7 @@ import (
 // the type system.
 type EnvVar string
 
-// Environment variables that TravisCI uses.
+// Environment variables that Jenkins uses.
 const (
 	VarBuildNumber    EnvVar = "BUILD_NUMBER"
 	VarBuildId        EnvVar = "BUILD_ID"

--- a/util/testutil/ci/jenkins/jenkins.go
+++ b/util/testutil/ci/jenkins/jenkins.go
@@ -1,0 +1,58 @@
+// Package jenkins implements some helper functions to use during
+// tests. Many times certain facilities are not available, or tests
+// must run differently.
+package jenkins
+
+import (
+	"os"
+	"strings"
+)
+
+// EnvVar is a type to use travis-only env var names with
+// the type system.
+type EnvVar string
+
+// Environment variables that TravisCI uses.
+const (
+	VarBuildNumber    EnvVar = "BUILD_NUMBER"
+	VarBuildId        EnvVar = "BUILD_ID"
+	VarBuildUrl       EnvVar = "BUILD_URL"
+	VarNodeName       EnvVar = "NODE_NAME"
+	VarJobName        EnvVar = "JOB_NAME"
+	VarBuildTag       EnvVar = "BUILD_TAG"
+	VarJenkinsUrl     EnvVar = "JENKINS_URL"
+	VarExecutorNumber EnvVar = "EXECUTOR_NUMBER"
+	VarJavaHome       EnvVar = "JAVA_HOME"
+	VarWorkspace      EnvVar = "WORKSPACE"
+	VarSvnRevision    EnvVar = "SVN_REVISION"
+	VarCvsBranch      EnvVar = "CVS_BRANCH"
+	VarGitCommit      EnvVar = "GIT_COMMIT"
+	VarGitUrl         EnvVar = "GIT_URL"
+	VarGitBranch      EnvVar = "GIT_BRANCH"
+)
+
+// IsRunning attempts to determine whether this process is
+// running on Jenkins CI. This is done by checking any of the
+// following:
+//
+//  JENKINS_URL is set
+//  BuildTag has prefix "jenkins-"
+//
+func IsRunning() bool {
+	return len(Env(VarJenkinsUrl)) > 0 || strings.HasPrefix(Env(VarBuildTag), "jenkins-")
+}
+
+// Env returns the value of a travis env variable.
+func Env(v EnvVar) string {
+	return os.Getenv(string(v))
+}
+
+// JobName returns the jenkins JOB_NAME of this build.
+func JobName() string {
+	return Env(VarJobName)
+}
+
+// BuildTag returns the jenkins BUILD_TAG.
+func BuildTag() string {
+	return Env(VarBuildTag)
+}

--- a/util/testutil/ci/jenkins/jenkins_test.go
+++ b/util/testutil/ci/jenkins/jenkins_test.go
@@ -1,0 +1,16 @@
+package jenkins
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestIsRunning(t *testing.T) {
+	hasPrefix := strings.HasPrefix(os.Getenv("BUILD_TAG"), "jenkins-")
+	tr := len(os.Getenv("JENKINS_URL")) > 0 || hasPrefix
+
+	if tr != IsRunning() {
+		t.Error("IsRunning() does not match TRAVIS && CI env var check")
+	}
+}

--- a/util/testutil/ci/travis/travis.go
+++ b/util/testutil/ci/travis/travis.go
@@ -1,0 +1,57 @@
+// Package travis implements some helper functions to use during
+// tests. Many times certain facilities are not available, or tests
+// must run differently.
+package travis
+
+import "os"
+
+// EnvVar is a type to use travis-only env var names with
+// the type system.
+type EnvVar string
+
+// Environment variables that TravisCI uses.
+const (
+	VarCI            EnvVar = "CI"
+	VarTravis        EnvVar = "TRAVIS"
+	VarBranch        EnvVar = "TRAVIS_BRANCH"
+	VarBuildDir      EnvVar = "TRAVIS_BUILD_DIR"
+	VarBuildId       EnvVar = "TRAVIS_BUILD_ID"
+	VarBuildNumber   EnvVar = "TRAVIS_BUILD_NUMBER"
+	VarCommit        EnvVar = "TRAVIS_COMMIT"
+	VarCommitRange   EnvVar = "TRAVIS_COMMIT_RANGE"
+	VarJobId         EnvVar = "TRAVIS_JOB_ID"
+	VarJobNumber     EnvVar = "TRAVIS_JOB_NUMBER"
+	VarPullRequest   EnvVar = "TRAVIS_PULL_REQUEST"
+	VarSecureEnvVars EnvVar = "TRAVIS_SECURE_ENV_VARS"
+	VarRepoSlug      EnvVar = "TRAVIS_REPO_SLUG"
+	VarOsName        EnvVar = "TRAVIS_OS_NAME"
+	VarTag           EnvVar = "TRAVIS_TAG"
+	VarGoVersion     EnvVar = "TRAVIS_GO_VERSION"
+)
+
+// IsRunning attempts to determine whether this process is
+// running on Travis-CI. This is done by checking ALL of the
+// following env vars are set:
+//
+//  CI=true
+//  TRAVIS=true
+//
+// Note: cannot just check CI.
+func IsRunning() bool {
+	return Env(VarCI) == "true" && Env(VarTravis) == "true"
+}
+
+// Env returns the value of a travis env variable.
+func Env(v EnvVar) string {
+	return os.Getenv(string(v))
+}
+
+// JobId returns the travis JOB_ID of this build.
+func JobId() string {
+	return Env(VarJobId)
+}
+
+// JobNumber returns the travis JOB_NUMBER of this build.
+func JobNumber() string {
+	return Env(VarJobNumber)
+}

--- a/util/testutil/ci/travis/travis_test.go
+++ b/util/testutil/ci/travis/travis_test.go
@@ -1,0 +1,13 @@
+package travis
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsRunning(t *testing.T) {
+	tr := os.Getenv("TRAVIS") == "true" && os.Getenv("CI") == "true"
+	if tr != IsRunning() {
+		t.Error("IsRunning() does not match TRAVIS && CI env var check")
+	}
+}


### PR DESCRIPTION
Before, we checked the env vars all over the place.
This PR moves all that into own packages. And adds
some nice env vars, should they become relevant to
other, tougher tests, or orchestration tools. And,
it caught a bug! We weren't checking it right...

@briantigerchow will like this PR.