### PR TITLE
Fix bad commit sha1 for go-multiaddr-net dependency

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -143,7 +143,7 @@
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-multiaddr-net",
-			"Rev": "04044c2289504304472715d827a8f564fa3759a8"
+			"Rev": "b6265d8119558acf3912db44abb34d97c30c3220"
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-multihash",


### PR DESCRIPTION
Currently running "godep restore" on master results in:

fatal: reference is not a tree: 04044c2289504304472715d827a8f564fa3759a8
godep: restore: exit status 128

This patch fixes this.

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>