### PR TITLE
Add "test/dependencies" dir and "godep restore" test

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -24,6 +24,7 @@ test: test_expensive
 test_expensive:
 	cd sharness && make TEST_EXPENSIVE=1
 	cd 3nodetest && make
+	cd dependencies && make
 
 test_cheap:
 	cd sharness && make

--- a/test/dependencies/Makefile
+++ b/test/dependencies/Makefile
@@ -1,0 +1,16 @@
+
+all: restore
+
+restore:
+	@echo "*** $@ ***"
+	which godep
+	mkdir -p tmp_gopath
+	OLD_GOPATH="$$GOPATH"
+	export GOPATH=$$(pwd)/tmp_gopath
+	cd ../..
+	godep restore
+	cd -
+	rm -rf tmp_gopath
+	export GOPATH="$$OLD_GOPATH"
+
+.PHONY: all restore


### PR DESCRIPTION
This is to avoid problems like those in PR #591 (Fix bad commit sha1 for go-multiaddr-net dependency).

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>