### PR TITLE
core/mount: make non-darwin archs see fuseversion

### DIFF
--- a/core/commands/mount.go
+++ b/core/commands/mount.go
@@ -1,0 +1,9 @@
+package commands
+
+import (
+	fuseversion "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-fuse-version"
+)
+
+// this file is only here to prevent go src tools (like godep) from
+// thinking fuseversion is not a required package by non-darwin archs.
+var _ = fuseversion.LocalFuseSystems


### PR DESCRIPTION
See the note:

// this file is only here to prevent go src tools (like godep) from
// thinking fuseversion is not a required package by non-darwin archs.