### PR TITLE
refactor(core) extract http

### DIFF
--- a/core/corehttp/commands.go
+++ b/core/corehttp/commands.go
@@ -1,0 +1,25 @@
+package corehttp
+
+import (
+	"net/http"
+	"os"
+
+	commands "github.com/jbenet/go-ipfs/commands"
+	cmdsHttp "github.com/jbenet/go-ipfs/commands/http"
+	core "github.com/jbenet/go-ipfs/core"
+	corecommands "github.com/jbenet/go-ipfs/core/commands"
+)
+
+const (
+	// TODO rename
+	originEnvKey = "API_ORIGIN"
+)
+
+func CommandsOption(cctx commands.Context) ServeOption {
+	return func(n *core.IpfsNode, mux *http.ServeMux) error {
+		origin := os.Getenv(originEnvKey)
+		cmdHandler := cmdsHttp.NewHandler(cctx, corecommands.Root, origin)
+		mux.Handle(cmdsHttp.ApiPath+"/", cmdHandler)
+		return nil
+	}
+}

--- a/core/corehttp/corehttp.go
+++ b/core/corehttp/corehttp.go
@@ -3,24 +3,18 @@ package corehttp
 import (
 	"fmt"
 	"net/http"
-	"os"
 
 	manners "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/braintree/manners"
 	ma "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 	manet "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr-net"
-	commands "github.com/jbenet/go-ipfs/commands"
-	cmdsHttp "github.com/jbenet/go-ipfs/commands/http"
 	core "github.com/jbenet/go-ipfs/core"
-	corecommands "github.com/jbenet/go-ipfs/core/commands"
 	eventlog "github.com/jbenet/go-ipfs/thirdparty/eventlog"
 )
 
 var log = eventlog.Logger("core/server")
 
 const (
-	// TODO rename
-	originEnvKey = "API_ORIGIN"
-	webuiPath    = "/ipfs/QmTWvqK9dYvqjAMAcCeUun8b45Fwu7wPhEN9B9TsGbkXfJ"
+// TODO rename
 )
 
 type ServeOption func(*core.IpfsNode, *http.ServeMux) error
@@ -33,29 +27,6 @@ func ListenAndServe(n *core.IpfsNode, addr ma.Multiaddr, options ...ServeOption)
 		}
 	}
 	return listenAndServe("API", n, addr, mux)
-}
-
-func CommandsOption(cctx commands.Context) ServeOption {
-	return func(n *core.IpfsNode, mux *http.ServeMux) error {
-		origin := os.Getenv(originEnvKey)
-		cmdHandler := cmdsHttp.NewHandler(cctx, corecommands.Root, origin)
-		mux.Handle(cmdsHttp.ApiPath+"/", cmdHandler)
-		return nil
-	}
-}
-
-func GatewayOption(n *core.IpfsNode, mux *http.ServeMux) error {
-	gateway, err := newGatewayHandler(n)
-	if err != nil {
-		return err
-	}
-	mux.Handle("/ipfs/", gateway)
-	return nil
-}
-
-func WebUIOption(n *core.IpfsNode, mux *http.ServeMux) error {
-	mux.Handle("/webui/", &redirectHandler{webuiPath})
-	return nil
 }
 
 func listenAndServe(name string, node *core.IpfsNode, addr ma.Multiaddr, mux *http.ServeMux) error {
@@ -89,12 +60,4 @@ func listenAndServe(name string, node *core.IpfsNode, addr ma.Multiaddr, mux *ht
 
 	log.Infof("server at %s terminated", addr)
 	return serverError
-}
-
-type redirectHandler struct {
-	path string
-}
-
-func (i *redirectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, i.path, 302)
 }

--- a/core/corehttp/corehttp.go
+++ b/core/corehttp/corehttp.go
@@ -1,0 +1,100 @@
+package corehttp
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	manners "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/braintree/manners"
+	ma "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
+	manet "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr-net"
+	commands "github.com/jbenet/go-ipfs/commands"
+	cmdsHttp "github.com/jbenet/go-ipfs/commands/http"
+	core "github.com/jbenet/go-ipfs/core"
+	corecommands "github.com/jbenet/go-ipfs/core/commands"
+	eventlog "github.com/jbenet/go-ipfs/thirdparty/eventlog"
+)
+
+var log = eventlog.Logger("core/server")
+
+const (
+	// TODO rename
+	originEnvKey = "API_ORIGIN"
+	webuiPath    = "/ipfs/QmTWvqK9dYvqjAMAcCeUun8b45Fwu7wPhEN9B9TsGbkXfJ"
+)
+
+type ServeOption func(*core.IpfsNode, *http.ServeMux) error
+
+func ListenAndServe(n *core.IpfsNode, addr ma.Multiaddr, options ...ServeOption) error {
+	mux := http.NewServeMux()
+	for _, option := range options {
+		if err := option(n, mux); err != nil {
+			return err
+		}
+	}
+	return listenAndServe("API", n, addr, mux)
+}
+
+func CommandsOption(cctx commands.Context) ServeOption {
+	return func(n *core.IpfsNode, mux *http.ServeMux) error {
+		origin := os.Getenv(originEnvKey)
+		cmdHandler := cmdsHttp.NewHandler(cctx, corecommands.Root, origin)
+		mux.Handle(cmdsHttp.ApiPath+"/", cmdHandler)
+		return nil
+	}
+}
+
+func GatewayOption(n *core.IpfsNode, mux *http.ServeMux) error {
+	gateway, err := newGatewayHandler(n)
+	if err != nil {
+		return err
+	}
+	mux.Handle("/ipfs/", gateway)
+	return nil
+}
+
+func WebUIOption(n *core.IpfsNode, mux *http.ServeMux) error {
+	mux.Handle("/webui/", &redirectHandler{webuiPath})
+	return nil
+}
+
+func listenAndServe(name string, node *core.IpfsNode, addr ma.Multiaddr, mux *http.ServeMux) error {
+	_, host, err := manet.DialArgs(addr)
+	if err != nil {
+		return err
+	}
+
+	server := manners.NewServer()
+
+	// if the server exits beforehand
+	var serverError error
+	serverExited := make(chan struct{})
+
+	go func() {
+		fmt.Printf("%s server listening on %s\n", name, addr)
+		serverError = server.ListenAndServe(host, mux)
+		close(serverExited)
+	}()
+
+	// wait for server to exit.
+	select {
+	case <-serverExited:
+
+	// if node being closed before server exits, close server
+	case <-node.Closing():
+		log.Infof("server at %s terminating...", addr)
+		server.Shutdown <- true
+		<-serverExited // now, DO wait until server exit
+	}
+
+	log.Infof("server at %s terminated", addr)
+	return serverError
+}
+
+type redirectHandler struct {
+	path string
+}
+
+func (i *redirectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, i.path, 302)
+}

--- a/core/corehttp/gateway.go
+++ b/core/corehttp/gateway.go
@@ -1,0 +1,16 @@
+package corehttp
+
+import (
+	"net/http"
+
+	core "github.com/jbenet/go-ipfs/core"
+)
+
+func GatewayOption(n *core.IpfsNode, mux *http.ServeMux) error {
+	gateway, err := newGatewayHandler(n)
+	if err != nil {
+		return err
+	}
+	mux.Handle("/ipfs/", gateway)
+	return nil
+}

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -1,4 +1,4 @@
-package main
+package corehttp
 
 import (
 	"html/template"
@@ -42,7 +42,7 @@ type gatewayHandler struct {
 	dirList *template.Template
 }
 
-func NewGatewayHandler(node *core.IpfsNode) (*gatewayHandler, error) {
+func newGatewayHandler(node *core.IpfsNode) (*gatewayHandler, error) {
 	i := &gatewayHandler{
 		node: node,
 	}

--- a/core/corehttp/webui.go
+++ b/core/corehttp/webui.go
@@ -1,0 +1,25 @@
+package corehttp
+
+import (
+	"net/http"
+
+	core "github.com/jbenet/go-ipfs/core"
+)
+
+const (
+	// TODO rename
+	webuiPath = "/ipfs/QmTWvqK9dYvqjAMAcCeUun8b45Fwu7wPhEN9B9TsGbkXfJ"
+)
+
+func WebUIOption(n *core.IpfsNode, mux *http.ServeMux) error {
+	mux.Handle("/webui/", &redirectHandler{webuiPath})
+	return nil
+}
+
+type redirectHandler struct {
+	path string
+}
+
+func (i *redirectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, i.path, 302)
+}


### PR DESCRIPTION
This PR extracts the core HTTP API functionality from the `go-ipfs/cmds/main` package.



It allows Golang IPFS developers to mount the `core.IpfsNode` onto an HTTP server. It ships with Commands, WebUI, and Gateway options.

An example of where this is used is the `ipfswatch` binary. https://github.com/jbenet/go-ipfs/blob/faded83473dc63a86e7921ef183c967c20379f66/cmd/ipfswatch/main.go#L71

```Go
package http

func ListenAndServe(n *core.IpfsNode, addr ma.Multiaddr, options ...ServeOption) error {}

type ServeOption func(*core.IpfsNode, *http.ServeMux) error {}

func DaemonOption(cctx commands.Context) ServeOption {}
func GatewayOption(n *core.IpfsNode, mux *http.ServeMux) error {}
func WebUIOption(n *core.IpfsNode, mux *http.ServeMux) error {}

```

Alternatively, this package could be called `coreserver`.