### PR TITLE
fix interface for coreunix.Cat, now takes a path

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -36,7 +36,6 @@ import (
 	dht "github.com/jbenet/go-ipfs/routing/dht"
 	offroute "github.com/jbenet/go-ipfs/routing/offline"
 	eventlog "github.com/jbenet/go-ipfs/thirdparty/eventlog"
-	util "github.com/jbenet/go-ipfs/util"
 	debugerror "github.com/jbenet/go-ipfs/util/debugerror"
 	lgbl "github.com/jbenet/go-ipfs/util/eventlog/loggables"
 )
@@ -302,10 +301,8 @@ func (n *IpfsNode) OnlineMode() bool {
 	}
 }
 
-// TODO expose way to resolve path name
-
-func (n *IpfsNode) Resolve(k util.Key) (*merkledag.Node, error) {
-	return (&path.Resolver{n.DAG}).ResolvePath(k.String())
+func (n *IpfsNode) Resolve(path string) (*merkledag.Node, error) {
+	return n.Resolver.ResolvePath(path)
 }
 
 // Bootstrap is undefined when node is not in OnlineMode

--- a/core/coreunix/cat.go
+++ b/core/coreunix/cat.go
@@ -5,11 +5,10 @@ import (
 
 	core "github.com/jbenet/go-ipfs/core"
 	uio "github.com/jbenet/go-ipfs/unixfs/io"
-	u "github.com/jbenet/go-ipfs/util"
 )
 
-func Cat(n *core.IpfsNode, k u.Key) (io.Reader, error) {
-	dagNode, err := n.Resolve(k)
+func Cat(n *core.IpfsNode, path string) (io.Reader, error) {
+	dagNode, err := n.Resolver.ResolvePath(path)
 	if err != nil {
 		return nil, err
 	}

--- a/test/epictest/addcat_test.go
+++ b/test/epictest/addcat_test.go
@@ -123,7 +123,7 @@ func DirectAddCat(data []byte, conf testutil.LatencyConfig) error {
 		return err
 	}
 
-	readerCatted, err := coreunix.Cat(catter, keyAdded)
+	readerCatted, err := coreunix.Cat(catter, keyAdded.String())
 	if err != nil {
 		return err
 	}

--- a/test/epictest/three_legged_cat_test.go
+++ b/test/epictest/three_legged_cat_test.go
@@ -71,7 +71,7 @@ func RunThreeLeggedCat(data []byte, conf testutil.LatencyConfig) error {
 		return err
 	}
 
-	readerCatted, err := coreunix.Cat(catter, keyAdded)
+	readerCatted, err := coreunix.Cat(catter, keyAdded.String())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The previous interface to Cat just took a Key, which didnt allow the user to specify a path, i changed this to accept a path.