### PR TITLE
Network Notifications

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -165,7 +165,7 @@
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-peerstream",
-			"Rev": "530b09b2300da11cc19f479289be5d014c146581"
+			"Rev": "bbe2a6461aa80ee25fd87eccf35bd54bac7f788d"
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-random",

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/.gitignore
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/.gitignore
@@ -1,0 +1,1 @@
+example/closer

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/.travis.yml
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/.travis.yml
@@ -1,11 +1,10 @@
 language: go
 
 go:
-  - 1.2
   - 1.3
   - 1.4
   - release
   - tip
 
 script:
-  - go test -race -cpu=5 -v ./...
+  - go test -race -cpu=5 ./...

--- a/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/test/ttest.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-peerstream/transport/test/ttest.go
@@ -350,6 +350,8 @@ func SubtestStressNSwarmNConnNStreamNMsg(t *testing.T, tr pst.Transport, nSwarm,
 		for _, a := range swarms {
 			for _, b := range swarms {
 				wg.Add(1)
+				a := a // race
+				b := b // race
 				go rateLimit(func() {
 					defer wg.Done()
 					openConnsAndRW(a, b)
@@ -368,6 +370,10 @@ func SubtestStressNSwarmNConnNStreamNMsg(t *testing.T, tr pst.Transport, nSwarm,
 
 	for err := range errs {
 		t.Error(err)
+	}
+
+	for _, s := range swarms {
+		s.Close()
 	}
 
 }

--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -339,6 +339,24 @@ func (bs *bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg
 	return "", nil
 }
 
+// Connected/Disconnected warns bitswap about peer connections
+func (bs *bitswap) PeerConnected(p peer.ID) {
+	// TODO: add to clientWorker??
+
+	peers := make(chan peer.ID)
+	err := bs.sendWantlistToPeers(context.TODO(), peers)
+	if err != nil {
+		log.Errorf("error sending wantlist: %s", err)
+	}
+	peers <- p
+	close(peers)
+}
+
+// Connected/Disconnected warns bitswap about peer connections
+func (bs *bitswap) PeerDisconnected(peer.ID) {
+	// TODO: release resources.
+}
+
 func (bs *bitswap) cancelBlocks(ctx context.Context, bkeys []u.Key) {
 	if len(bkeys) < 1 {
 		return

--- a/exchange/bitswap/network/interface.go
+++ b/exchange/bitswap/network/interface.go
@@ -40,6 +40,10 @@ type Receiver interface {
 		destination peer.ID, outgoing bsmsg.BitSwapMessage)
 
 	ReceiveError(error)
+
+	// Connected/Disconnected warns bitswap about peer connections
+	PeerConnected(peer.ID)
+	PeerDisconnected(peer.ID)
 }
 
 type Routing interface {

--- a/exchange/bitswap/testnet/network_test.go
+++ b/exchange/bitswap/testnet/network_test.go
@@ -146,3 +146,10 @@ func (lam *lambdaImpl) ReceiveMessage(ctx context.Context,
 func (lam *lambdaImpl) ReceiveError(err error) {
 	// TODO log error
 }
+
+func (lam *lambdaImpl) PeerConnected(p peer.ID) {
+	// TODO
+}
+func (lam *lambdaImpl) PeerDisconnected(peer.ID) {
+	// TODO
+}

--- a/p2p/net/interface.go
+++ b/p2p/net/interface.go
@@ -111,6 +111,10 @@ type Dialer interface {
 
 	// ConnsToPeer returns the connections in this Netowrk for given peer.
 	ConnsToPeer(p peer.ID) []Conn
+
+	// Notify/StopNotify register and unregister a notifiee for signals
+	Notify(Notifiee)
+	StopNotify(Notifiee)
 }
 
 // Connectedness signals the capacity for a connection with a given node.
@@ -131,3 +135,16 @@ const (
 	// (should signal "made effort, failed")
 	CannotConnect
 )
+
+// Notifiee is an interface for an object wishing to receive
+// notifications from a Network.
+type Notifiee interface {
+	Connected(Network, Conn)      // called when a connection opened
+	Disconnected(Network, Conn)   // called when a connection closed
+	OpenedStream(Network, Stream) // called when a stream opened
+	ClosedStream(Network, Stream) // called when a stream closed
+
+	// TODO
+	// PeerConnected(Network, peer.ID)    // called when a peer connected
+	// PeerDisconnected(Network, peer.ID) // called when a peer disconnected
+}

--- a/p2p/net/mock/mock_conn.go
+++ b/p2p/net/mock/mock_conn.go
@@ -37,6 +37,9 @@ func (c *conn) Close() error {
 		s.Close()
 	}
 	c.net.removeConn(c)
+	c.net.notifyAll(func(n inet.Notifiee) {
+		n.Disconnected(c.net, c)
+	})
 	return nil
 }
 
@@ -73,11 +76,17 @@ func (c *conn) allStreams() []inet.Stream {
 func (c *conn) remoteOpenedStream(s *stream) {
 	c.addStream(s)
 	c.net.handleNewStream(s)
+	c.net.notifyAll(func(n inet.Notifiee) {
+		n.OpenedStream(c.net, s)
+	})
 }
 
 func (c *conn) openStream() *stream {
 	sl, sr := c.link.newStreamPair()
 	c.addStream(sl)
+	c.net.notifyAll(func(n inet.Notifiee) {
+		n.OpenedStream(c.net, sl)
+	})
 	c.rconn.remoteOpenedStream(sr)
 	return sl
 }

--- a/p2p/net/mock/mock_notif_test.go
+++ b/p2p/net/mock/mock_notif_test.go
@@ -1,0 +1,198 @@
+package mocknet
+
+import (
+	"testing"
+	"time"
+
+	inet "github.com/jbenet/go-ipfs/p2p/net"
+
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
+)
+
+func TestNotifications(t *testing.T) {
+	t.Parallel()
+
+	mn, err := FullMeshLinked(context.Background(), 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	timeout := 5 * time.Second
+
+	// signup notifs
+	nets := mn.Nets()
+	notifiees := make([]*netNotifiee, len(nets))
+	for i, pn := range nets {
+		n := newNetNotifiee()
+		pn.Notify(n)
+		notifiees[i] = n
+	}
+
+	// connect all
+	for _, n1 := range nets {
+		for _, n2 := range nets {
+			if n1 == n2 {
+				continue
+			}
+			if _, err := mn.ConnectNets(n1, n2); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// test everyone got the correct connection opened calls
+	for i, s := range nets {
+		n := notifiees[i]
+		for _, s2 := range nets {
+			cos := s.ConnsToPeer(s2.LocalPeer())
+			func() {
+				for i := 0; i < len(cos); i++ {
+					var c inet.Conn
+					select {
+					case c = <-n.connected:
+					case <-time.After(timeout):
+						t.Fatal("timeout")
+					}
+					for _, c2 := range cos {
+						if c == c2 {
+							t.Log("got notif for conn")
+							return
+						}
+					}
+					t.Error("connection not found")
+				}
+			}()
+		}
+	}
+
+	complement := func(c inet.Conn) (inet.Network, *netNotifiee, *conn) {
+		for i, s := range nets {
+			for _, c2 := range s.Conns() {
+				if c2.(*conn).rconn == c {
+					return s, notifiees[i], c2.(*conn)
+				}
+			}
+		}
+		t.Fatal("complementary conn not found", c)
+		return nil, nil, nil
+	}
+
+	testOCStream := func(n *netNotifiee, s inet.Stream) {
+		var s2 inet.Stream
+		select {
+		case s2 = <-n.openedStream:
+			t.Log("got notif for opened stream")
+		case <-time.After(timeout):
+			t.Fatal("timeout")
+		}
+		if s != nil && s != s2 {
+			t.Fatalf("got incorrect stream %p %p", s, s2)
+		}
+
+		select {
+		case s2 = <-n.closedStream:
+			t.Log("got notif for closed stream")
+		case <-time.After(timeout):
+			t.Fatal("timeout")
+		}
+		if s != nil && s != s2 {
+			t.Fatalf("got incorrect stream %p %p", s, s2)
+		}
+	}
+
+	streams := make(chan inet.Stream)
+	for _, s := range nets {
+		s.SetStreamHandler(func(s inet.Stream) {
+			streams <- s
+			s.Close()
+		})
+	}
+
+	// there's one stream per conn that we need to drain....
+	// unsure where these are coming from
+	for i, _ := range nets {
+		n := notifiees[i]
+		testOCStream(n, nil)
+		testOCStream(n, nil)
+		testOCStream(n, nil)
+		testOCStream(n, nil)
+	}
+
+	// open a streams in each conn
+	for i, s := range nets {
+		conns := s.Conns()
+		for _, c := range conns {
+			_, n2, c2 := complement(c)
+			st1, err := c.NewStream()
+			if err != nil {
+				t.Error(err)
+			} else {
+				t.Logf("%s %s <--%p--> %s %s", c.LocalPeer(), c.LocalMultiaddr(), st1, c.RemotePeer(), c.RemoteMultiaddr())
+				// st1.Write([]byte("hello"))
+				st1.Close()
+				st2 := <-streams
+				t.Logf("%s %s <--%p--> %s %s", c2.LocalPeer(), c2.LocalMultiaddr(), st2, c2.RemotePeer(), c2.RemoteMultiaddr())
+				testOCStream(notifiees[i], st1)
+				testOCStream(n2, st2)
+			}
+		}
+	}
+
+	// close conns
+	for i, s := range nets {
+		n := notifiees[i]
+		for _, c := range s.Conns() {
+			_, n2, c2 := complement(c)
+			c.(*conn).Close()
+			c2.Close()
+
+			var c3, c4 inet.Conn
+			select {
+			case c3 = <-n.disconnected:
+			case <-time.After(timeout):
+				t.Fatal("timeout")
+			}
+			if c != c3 {
+				t.Fatal("got incorrect conn", c, c3)
+			}
+
+			select {
+			case c4 = <-n2.disconnected:
+			case <-time.After(timeout):
+				t.Fatal("timeout")
+			}
+			if c2 != c4 {
+				t.Fatal("got incorrect conn", c, c2)
+			}
+		}
+	}
+}
+
+type netNotifiee struct {
+	connected    chan inet.Conn
+	disconnected chan inet.Conn
+	openedStream chan inet.Stream
+	closedStream chan inet.Stream
+}
+
+func newNetNotifiee() *netNotifiee {
+	return &netNotifiee{
+		connected:    make(chan inet.Conn),
+		disconnected: make(chan inet.Conn),
+		openedStream: make(chan inet.Stream),
+		closedStream: make(chan inet.Stream),
+	}
+}
+
+func (nn *netNotifiee) Connected(n inet.Network, v inet.Conn) {
+	nn.connected <- v
+}
+func (nn *netNotifiee) Disconnected(n inet.Network, v inet.Conn) {
+	nn.disconnected <- v
+}
+func (nn *netNotifiee) OpenedStream(n inet.Network, v inet.Stream) {
+	nn.openedStream <- v
+}
+func (nn *netNotifiee) ClosedStream(n inet.Network, v inet.Stream) {
+	nn.closedStream <- v
+}

--- a/p2p/net/mock/mock_stream.go
+++ b/p2p/net/mock/mock_stream.go
@@ -19,8 +19,11 @@ func (s *stream) Close() error {
 		r.Close()
 	}
 	if w, ok := (s.Writer).(io.Closer); ok {
-		return w.Close()
+		w.Close()
 	}
+	s.conn.net.notifyAll(func(n inet.Notifiee) {
+		n.ClosedStream(s.conn.net, s)
+	})
 	return nil
 }
 

--- a/p2p/net/swarm/swarm_net.go
+++ b/p2p/net/swarm/swarm_net.go
@@ -154,3 +154,13 @@ func (n *Network) SetConnHandler(h inet.ConnHandler) {
 func (n *Network) String() string {
 	return fmt.Sprintf("<Network %s>", n.LocalPeer())
 }
+
+// Notify signs up Notifiee to receive signals when events happen
+func (n *Network) Notify(f inet.Notifiee) {
+	n.Swarm().Notify(f)
+}
+
+// StopNotify unregisters Notifiee fromr receiving signals
+func (n *Network) StopNotify(f inet.Notifiee) {
+	n.Swarm().StopNotify(f)
+}

--- a/p2p/net/swarm/swarm_notif_test.go
+++ b/p2p/net/swarm/swarm_notif_test.go
@@ -1,0 +1,186 @@
+package swarm
+
+import (
+	"testing"
+	"time"
+
+	inet "github.com/jbenet/go-ipfs/p2p/net"
+
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
+)
+
+func TestNotifications(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	swarms := makeSwarms(ctx, t, 5)
+	defer func() {
+		for _, s := range swarms {
+			s.Close()
+		}
+	}()
+
+	timeout := 5 * time.Second
+
+	// signup notifs
+	notifiees := make([]*netNotifiee, len(swarms))
+	for i, swarm := range swarms {
+		n := newNetNotifiee()
+		swarm.Notify(n)
+		notifiees[i] = n
+	}
+
+	connectSwarms(t, ctx, swarms)
+
+	<-time.After(time.Millisecond)
+	// should've gotten 5 by now.
+
+	// test everyone got the correct connection opened calls
+	for i, s := range swarms {
+		n := notifiees[i]
+		for _, s2 := range swarms {
+			if s == s2 {
+				continue
+			}
+
+			cos := s.ConnectionsToPeer(s2.LocalPeer())
+			func() {
+				for i := 0; i < len(cos); i++ {
+					var c inet.Conn
+					select {
+					case c = <-n.connected:
+					case <-time.After(timeout):
+						t.Fatal("timeout")
+					}
+					for _, c2 := range cos {
+						if c == c2 {
+							t.Log("got notif for conn", c)
+							return
+						}
+					}
+					t.Error("connection not found", c)
+				}
+			}()
+		}
+	}
+
+	complement := func(c inet.Conn) (*Swarm, *netNotifiee, *Conn) {
+		for i, s := range swarms {
+			for _, c2 := range s.Connections() {
+				if c.LocalMultiaddr().Equal(c2.RemoteMultiaddr()) &&
+					c2.LocalMultiaddr().Equal(c.RemoteMultiaddr()) {
+					return s, notifiees[i], c2
+				}
+			}
+		}
+		t.Fatal("complementary conn not found", c)
+		return nil, nil, nil
+	}
+
+	testOCStream := func(n *netNotifiee, s inet.Stream) {
+		var s2 inet.Stream
+		select {
+		case s2 = <-n.openedStream:
+			t.Log("got notif for opened stream")
+		case <-time.After(timeout):
+			t.Fatal("timeout")
+		}
+		if s != s2 {
+			t.Fatal("got incorrect stream", s.Conn(), s2.Conn())
+		}
+
+		select {
+		case s2 = <-n.closedStream:
+			t.Log("got notif for closed stream")
+		case <-time.After(timeout):
+			t.Fatal("timeout")
+		}
+		if s != s2 {
+			t.Fatal("got incorrect stream", s.Conn(), s2.Conn())
+		}
+	}
+
+	streams := make(chan inet.Stream)
+	for _, s := range swarms {
+		s.SetStreamHandler(func(s inet.Stream) {
+			streams <- s
+			s.Close()
+		})
+	}
+
+	// open a streams in each conn
+	for i, s := range swarms {
+		for _, c := range s.Connections() {
+			_, n2, _ := complement(c)
+
+			st1, err := c.NewStream()
+			if err != nil {
+				t.Error(err)
+			} else {
+				st1.Write([]byte("hello"))
+				st1.Close()
+				testOCStream(notifiees[i], st1)
+				st2 := <-streams
+				testOCStream(n2, st2)
+			}
+		}
+	}
+
+	// close conns
+	for i, s := range swarms {
+		n := notifiees[i]
+		for _, c := range s.Connections() {
+			_, n2, c2 := complement(c)
+			c.Close()
+			c2.Close()
+
+			var c3, c4 inet.Conn
+			select {
+			case c3 = <-n.disconnected:
+			case <-time.After(timeout):
+				t.Fatal("timeout")
+			}
+			if c != c3 {
+				t.Fatal("got incorrect conn", c, c3)
+			}
+
+			select {
+			case c4 = <-n2.disconnected:
+			case <-time.After(timeout):
+				t.Fatal("timeout")
+			}
+			if c2 != c4 {
+				t.Fatal("got incorrect conn", c, c2)
+			}
+		}
+	}
+}
+
+type netNotifiee struct {
+	connected    chan inet.Conn
+	disconnected chan inet.Conn
+	openedStream chan inet.Stream
+	closedStream chan inet.Stream
+}
+
+func newNetNotifiee() *netNotifiee {
+	return &netNotifiee{
+		connected:    make(chan inet.Conn),
+		disconnected: make(chan inet.Conn),
+		openedStream: make(chan inet.Stream),
+		closedStream: make(chan inet.Stream),
+	}
+}
+
+func (nn *netNotifiee) Connected(n inet.Network, v inet.Conn) {
+	nn.connected <- v
+}
+func (nn *netNotifiee) Disconnected(n inet.Network, v inet.Conn) {
+	nn.disconnected <- v
+}
+func (nn *netNotifiee) OpenedStream(n inet.Network, v inet.Stream) {
+	nn.openedStream <- v
+}
+func (nn *netNotifiee) ClosedStream(n inet.Network, v inet.Stream) {
+	nn.closedStream <- v
+}

--- a/routing/dht/notif.go
+++ b/routing/dht/notif.go
@@ -1,0 +1,33 @@
+package dht
+
+import (
+	inet "github.com/jbenet/go-ipfs/p2p/net"
+)
+
+// netNotifiee defines methods to be used with the IpfsDHT
+type netNotifiee IpfsDHT
+
+func (nn *netNotifiee) DHT() *IpfsDHT {
+	return (*IpfsDHT)(nn)
+}
+
+func (nn *netNotifiee) Connected(n inet.Network, v inet.Conn) {
+	dht := nn.DHT()
+	select {
+	case <-dht.Closing():
+		return
+	}
+	dht.Update(dht.Context(), v.RemotePeer())
+}
+
+func (nn *netNotifiee) Disconnected(n inet.Network, v inet.Conn) {
+	dht := nn.DHT()
+	select {
+	case <-dht.Closing():
+		return
+	}
+	dht.routingTable.Remove(v.RemotePeer())
+}
+
+func (nn *netNotifiee) OpenedStream(n inet.Network, v inet.Stream) {}
+func (nn *netNotifiee) ClosedStream(n inet.Network, v inet.Stream) {}

--- a/routing/kbucket/bucket.go
+++ b/routing/kbucket/bucket.go
@@ -30,6 +30,16 @@ func (b *Bucket) find(id peer.ID) *list.Element {
 	return nil
 }
 
+func (b *Bucket) remove(id peer.ID) {
+	b.lk.RLock()
+	defer b.lk.RUnlock()
+	for e := b.list.Front(); e != nil; e = e.Next() {
+		if e.Value.(peer.ID) == id {
+			b.list.Remove(e)
+		}
+	}
+}
+
 func (b *Bucket) moveToFront(e *list.Element) {
 	b.lk.Lock()
 	b.list.MoveToFront(e)

--- a/routing/kbucket/table.go
+++ b/routing/kbucket/table.go
@@ -87,6 +87,23 @@ func (rt *RoutingTable) Update(p peer.ID) peer.ID {
 	return ""
 }
 
+// Remove deletes a peer from the routing table. This is to be used
+// when we are sure a node has disconnected completely.
+func (rt *RoutingTable) Remove(p peer.ID) {
+	rt.tabLock.Lock()
+	defer rt.tabLock.Unlock()
+	peerID := ConvertPeerID(p)
+	cpl := commonPrefixLen(peerID, rt.local)
+
+	bucketID := cpl
+	if bucketID >= len(rt.Buckets) {
+		bucketID = len(rt.Buckets) - 1
+	}
+
+	bucket := rt.Buckets[bucketID]
+	bucket.remove(p)
+}
+
 func (rt *RoutingTable) nextBucket() peer.ID {
 	bucket := rt.Buckets[len(rt.Buckets)-1]
 	newBucket := bucket.Split(len(rt.Buckets)-1, rt.local)


### PR DESCRIPTION
This PR introduces network notifications. These are
typesafe (with the Notifiee pattern) and well scoped
in their own notification-responder "objects". (I say
"objects" because many times they're just another obj
casted)

The network notifications interface is:

```go
// Notifiee is an interface for an object wishing to receive
// notifications from a Network.
type Notifiee interface {
  Connected(Network, Conn)      // called when a connection opened
  Disconnected(Network, Conn)   // called when a connection closed
  OpenedStream(Network, Stream) // called when a stream opened
  ClosedStream(Network, Stream) // called when a stream closed

  // TODO
  // PeerConnected(Network, peer.ID)    // called when a peer connected
  // PeerDisconnected(Network, peer.ID) // called when a peer disconnected
}
```