### PR TITLE
change ipns resolve/publish to store raw keys, not b58 encoded

### DIFF
--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -41,6 +41,12 @@ var IDCmd = &cmds.Command{
 		ShortDescription: `
 Prints out information about the specified peer,
 if no peer is specified, prints out local peers info.
+
+ipfs id supports the format option for output with the following keys:
+<id> : the peers id
+<aver>: agent version
+<pver>: protocol version
+<pubkey>: public key
 `,
 	},
 	Arguments: []cmds.Argument{

--- a/core/core.go
+++ b/core/core.go
@@ -367,6 +367,9 @@ func (n *IpfsNode) SetupOfflineRouting() error {
 	}
 
 	n.Routing = offroute.NewOfflineRouter(n.Repo.Datastore(), n.PrivateKey)
+
+	n.Namesys = namesys.NewNameSystem(n.Routing)
+
 	return nil
 }
 

--- a/fuse/ipns/ipns_test.go
+++ b/fuse/ipns/ipns_test.go
@@ -3,6 +3,7 @@ package ipns
 import (
 	"bytes"
 	"crypto/rand"
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -252,7 +253,7 @@ func TestFastRepublish(t *testing.T) {
 	writeFileData(t, dataA, fname) // random
 	<-time.After(shortRepublishTimeout * 2)
 	log.Debug("resolving first hash")
-	resolvedHash, err := node.Namesys.Resolve(pubkeyHash)
+	resolvedHash, err := node.Namesys.Resolve(context.Background(), pubkeyHash)
 	if err != nil {
 		t.Fatal("resolve err:", pubkeyHash, err)
 	}
@@ -271,7 +272,7 @@ func TestFastRepublish(t *testing.T) {
 	}(shortRepublishTimeout)
 
 	hasPublished := func() bool {
-		res, err := node.Namesys.Resolve(pubkeyHash)
+		res, err := node.Namesys.Resolve(context.Background(), pubkeyHash)
 		if err != nil {
 			t.Fatalf("resolve err: %v", err)
 		}

--- a/namesys/dns.go
+++ b/namesys/dns.go
@@ -3,9 +3,12 @@ package namesys
 import (
 	"net"
 
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
 	b58 "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-base58"
 	isd "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-is-domain"
 	mh "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
+
+	u "github.com/jbenet/go-ipfs/util"
 )
 
 // DNSResolver implements a Resolver on DNS domains
@@ -22,7 +25,7 @@ func (r *DNSResolver) CanResolve(name string) bool {
 // Resolve implements Resolver
 // TXT records for a given domain name should contain a b58
 // encoded multihash.
-func (r *DNSResolver) Resolve(name string) (string, error) {
+func (r *DNSResolver) Resolve(ctx context.Context, name string) (u.Key, error) {
 	log.Info("DNSResolver resolving %v", name)
 	txt, err := net.LookupTXT(name)
 	if err != nil {
@@ -39,7 +42,7 @@ func (r *DNSResolver) Resolve(name string) (string, error) {
 		if err != nil {
 			continue
 		}
-		return t, nil
+		return u.Key(chk), nil
 	}
 
 	return "", ErrResolveFailed

--- a/namesys/interface.go
+++ b/namesys/interface.go
@@ -3,7 +3,9 @@ package namesys
 import (
 	"errors"
 
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
 	ci "github.com/jbenet/go-ipfs/p2p/crypto"
+	u "github.com/jbenet/go-ipfs/util"
 )
 
 // ErrResolveFailed signals an error when attempting to resolve.
@@ -28,7 +30,7 @@ type NameSystem interface {
 type Resolver interface {
 
 	// Resolve looks up a name, and returns the value previously published.
-	Resolve(name string) (value string, err error)
+	Resolve(ctx context.Context, name string) (value u.Key, err error)
 
 	// CanResolve checks whether this Resolver can resolve a name
 	CanResolve(name string) bool
@@ -39,5 +41,5 @@ type Publisher interface {
 
 	// Publish establishes a name-value mapping.
 	// TODO make this not PrivKey specific.
-	Publish(name ci.PrivKey, value string) error
+	Publish(ctx context.Context, name ci.PrivKey, value u.Key) error
 }

--- a/namesys/namesys.go
+++ b/namesys/namesys.go
@@ -1,8 +1,10 @@
 package namesys
 
 import (
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
 	ci "github.com/jbenet/go-ipfs/p2p/crypto"
 	routing "github.com/jbenet/go-ipfs/routing"
+	u "github.com/jbenet/go-ipfs/util"
 )
 
 // ipnsNameSystem implements IPNS naming.
@@ -32,10 +34,10 @@ func NewNameSystem(r routing.IpfsRouting) NameSystem {
 }
 
 // Resolve implements Resolver
-func (ns *ipns) Resolve(name string) (string, error) {
+func (ns *ipns) Resolve(ctx context.Context, name string) (u.Key, error) {
 	for _, r := range ns.resolvers {
 		if r.CanResolve(name) {
-			return r.Resolve(name)
+			return r.Resolve(ctx, name)
 		}
 	}
 	return "", ErrResolveFailed
@@ -52,6 +54,6 @@ func (ns *ipns) CanResolve(name string) bool {
 }
 
 // Publish implements Publisher
-func (ns *ipns) Publish(name ci.PrivKey, value string) error {
-	return ns.publisher.Publish(name, value)
+func (ns *ipns) Publish(ctx context.Context, name ci.PrivKey, value u.Key) error {
+	return ns.publisher.Publish(ctx, name, value)
 }

--- a/namesys/proquint.go
+++ b/namesys/proquint.go
@@ -3,7 +3,9 @@ package namesys
 import (
 	"errors"
 
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
 	proquint "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/bren2010/proquint"
+	u "github.com/jbenet/go-ipfs/util"
 )
 
 type ProquintResolver struct{}
@@ -15,10 +17,10 @@ func (r *ProquintResolver) CanResolve(name string) bool {
 }
 
 // Resolve implements Resolver. Decodes the proquint string.
-func (r *ProquintResolver) Resolve(name string) (string, error) {
+func (r *ProquintResolver) Resolve(ctx context.Context, name string) (u.Key, error) {
 	ok := r.CanResolve(name)
 	if !ok {
 		return "", errors.New("not a valid proquint string")
 	}
-	return string(proquint.Decode(name)), nil
+	return u.Key(proquint.Decode(name)), nil
 }

--- a/namesys/resolve_test.go
+++ b/namesys/resolve_test.go
@@ -1,6 +1,7 @@
 package namesys
 
 import (
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
 	"testing"
 
 	mockrouting "github.com/jbenet/go-ipfs/routing/mock"
@@ -19,13 +20,13 @@ func TestRoutingResolve(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = publisher.Publish(privk, "Hello")
+	err = publisher.Publish(context.Background(), privk, "Hello")
 	if err == nil {
 		t.Fatal("should have errored out when publishing a non-multihash val")
 	}
 
-	h := u.Key(u.Hash([]byte("Hello"))).Pretty()
-	err = publisher.Publish(privk, h)
+	h := u.Key(u.Hash([]byte("Hello")))
+	err = publisher.Publish(context.Background(), privk, h)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +37,7 @@ func TestRoutingResolve(t *testing.T) {
 	}
 
 	pkhash := u.Hash(pubkb)
-	res, err := resolver.Resolve(u.Key(pkhash).Pretty())
+	res, err := resolver.Resolve(context.Background(), u.Key(pkhash).Pretty())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/namesys/routing.go
+++ b/namesys/routing.go
@@ -38,9 +38,8 @@ func (r *routingResolver) CanResolve(name string) bool {
 
 // Resolve implements Resolver. Uses the IPFS routing system to resolve SFS-like
 // names.
-func (r *routingResolver) Resolve(name string) (string, error) {
+func (r *routingResolver) Resolve(ctx context.Context, name string) (u.Key, error) {
 	log.Debugf("RoutingResolve: '%s'", name)
-	ctx := context.TODO()
 	hash, err := mh.FromB58String(name)
 	if err != nil {
 		log.Warning("RoutingResolve: bad input hash: [%s]\n", name)
@@ -88,5 +87,5 @@ func (r *routingResolver) Resolve(name string) (string, error) {
 	}
 
 	// ok sig checks out. this is a valid name.
-	return string(entry.GetValue()), nil
+	return u.Key(entry.GetValue()), nil
 }

--- a/test/sharness/t0100-name.sh
+++ b/test/sharness/t0100-name.sh
@@ -13,14 +13,19 @@ test_init_ipfs
 test_expect_success "'ipfs name publish' succeeds" '
 	PEERID=`ipfs id -format="<id>"` &&
 	HASH=QmYpv2VEsxzTTXRYX3PjDg961cnJE3kY1YDXLycHGQ3zZB &&
-	ipfs name publish $HASH > publish_out &&
+	ipfs name publish $HASH > publish_out
+'
+
+test_expect_success "publish output looks good" '
 	echo Published name $PEERID to $HASH > expected1 &&
 	test_cmp publish_out expected1
-
 '
 
 test_expect_success "'ipfs name resolve' succeeds" '
-	ipfs name resolve $PEERID > output &&
+	ipfs name resolve $PEERID > output
+'
+
+test_expect_success "resolve output looks good" '
 	printf "%s" $HASH > expected2 &&
 	test_cmp output expected2
 '

--- a/test/sharness/t0100-name.sh
+++ b/test/sharness/t0100-name.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# Copyright (c) 2014 Jeromy Johnson
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test ipfs repo operations"
+
+. lib/test-lib.sh
+
+test_init_ipfs
+
+test_expect_success "'ipfs name publish' succeeds" '
+	PEERID=`ipfs id -format="<id>"` &&
+	HASH=QmYpv2VEsxzTTXRYX3PjDg961cnJE3kY1YDXLycHGQ3zZB &&
+	ipfs name publish $HASH > publish_out &&
+	echo Published name $PEERID to $HASH > expected1 &&
+	test_cmp publish_out expected1
+
+'
+
+test_expect_success "'ipfs name resolve' succeeds" '
+	ipfs name resolve $PEERID > output &&
+	printf "%s" $HASH > expected2 &&
+	test_cmp output expected2
+'
+
+test_done


### PR DESCRIPTION
This PR addresses issue #669. I also implemented a basic 'format' option for `ipfs id` to make sharness testing easier (i needed to know the peers ID for resolving tests).