### PR TITLE
Add Ed25519 support

### DIFF
--- a/namesys/resolve_test.go
+++ b/namesys/resolve_test.go
@@ -15,7 +15,7 @@ func TestRoutingResolve(t *testing.T) {
 	resolver := NewRoutingResolver(d)
 	publisher := NewRoutingPublisher(d)
 
-	privk, pubk, err := testutil.RandTestKeyPair(512)
+	privk, pubk, err := testutil.RandTestRSAKeyPair(512)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/p2p/crypto/ed25519.go
+++ b/p2p/crypto/ed25519.go
@@ -2,6 +2,7 @@ package crypto
 
 import (
 	"errors"
+	"fmt"
 
 	ed "github.com/mildred/ed25519/src"
 )
@@ -64,7 +65,7 @@ func (sk *Ed25519PrivateKey) Hash() ([]byte, error) {
 
 func UnmarshalEd25519PrivateKey(b []byte) (*Ed25519PrivateKey, error) {
 	if len(b) != ed.PrivateKeySize+ed.PublicKeySize {
-		return nil, errors.New("Cannot unmarshall Ed2551 private key of incorrect size")
+		return nil, errors.New("Cannot unmarshall Ed2551 private key of incorrect size ")
 	}
 	var priv Ed25519PrivateKey
 	copy(priv.sk[:], b[:ed.PrivateKeySize])
@@ -79,7 +80,7 @@ func MarshalEd25519PrivateKey(k *Ed25519PrivateKey) []byte {
 
 func UnmarshalEd25519PublicKey(b []byte) (*Ed25519PublicKey, error) {
 	if len(b) != ed.PublicKeySize {
-		return nil, errors.New("Cannot unmarshall Ed2551 public key of incorrect size")
+		return nil, fmt.Errorf("Cannot unmarshall Ed2551 public key of incorrect size %d", len(b))
 	}
 	var pub Ed25519PublicKey
 	copy(b, pub.k[:])

--- a/p2p/crypto/ed25519.go
+++ b/p2p/crypto/ed25519.go
@@ -1,0 +1,110 @@
+package crypto
+
+import (
+	"errors"
+
+	ed "github.com/mildred/ed25519/src"
+)
+
+type edPubKey [32]byte
+type edPrivKey [64]byte
+type edSeed [32]byte
+
+type Ed25519PrivateKey struct {
+	sk ed.PrivateKey
+	pk ed.PublicKey
+}
+
+type Ed25519PublicKey struct {
+	k ed.PublicKey
+}
+
+func (pk *Ed25519PublicKey) Verify(data, sig []byte) (bool, error) {
+	if len(sig) != ed.SignatureSize {
+		return false, errors.New("Incorrect signature size")
+	}
+	var sig2 ed.Signature
+	copy(sig2[:], sig)
+	return ed.Verify(sig2, data, pk.k), nil
+}
+
+func (pk *Ed25519PublicKey) Bytes() ([]byte, error) {
+	return pk.k[:], nil
+}
+
+// Equals checks whether this key is equal to another
+func (pk *Ed25519PublicKey) Equals(k Key) bool {
+	return KeyEqual(pk, k)
+}
+
+func (pk *Ed25519PublicKey) Hash() ([]byte, error) {
+	return pk.k[:], nil
+}
+
+func (pk *Ed25519PublicKey) Encrypt(data []byte) ([]byte, error) {
+	var empty []byte
+	return empty, errors.New("Cannot encrypt not knowing a private key")
+}
+
+func (pk *Ed25519PrivateKey) Decrypt(b []byte) ([]byte, error) {
+	var empty []byte
+	return empty, errors.New("Cannot decrypt not knowing the public key of the other side")
+}
+
+func (sk *Ed25519PrivateKey) GenSecret() ([]byte, error) {
+	buf, err := ed.CreateSeed()
+	return buf[:], err
+}
+
+func (sk *Ed25519PrivateKey) Sign(message []byte) ([]byte, error) {
+	sig := ed.Sign(message, sk.pk, sk.sk)
+	return sig[:], nil
+}
+
+func (sk *Ed25519PrivateKey) GetPublic() PubKey {
+	return &Ed25519PublicKey{sk.pk}
+}
+
+func (sk *Ed25519PrivateKey) Bytes() (res []byte, err error) {
+	res = append(res, sk.sk[:]...)
+	res = append(res, sk.pk[:]...)
+	err = nil
+	return res, err
+}
+
+// Equals checks whether this key is equal to another
+func (sk *Ed25519PrivateKey) Equals(k Key) bool {
+	return KeyEqual(sk, k)
+}
+
+func (sk *Ed25519PrivateKey) Hash() ([]byte, error) {
+	return KeyHash(sk)
+}
+
+func UnmarshalEd25519PrivateKey(b []byte) (*Ed25519PrivateKey, error) {
+	if len(b) != ed.PrivateKeySize+ed.PublicKeySize {
+		return nil, errors.New("Cannot unmarshall Ed2551 private key of incorrect size")
+	}
+	var priv Ed25519PrivateKey
+	copy(priv.sk[:], b[:ed.PrivateKeySize])
+	copy(priv.pk[:], b[ed.PrivateKeySize:])
+	return &priv, nil
+}
+
+func MarshalEd25519PrivateKey(k *Ed25519PrivateKey) []byte {
+	res, _ := k.Bytes()
+	return res
+}
+
+func UnmarshalEd25519PublicKey(b []byte) (*Ed25519PublicKey, error) {
+	if len(b) != ed.PublicKeySize {
+		return nil, errors.New("Cannot unmarshall Ed2551 public key of incorrect size")
+	}
+	var pub Ed25519PublicKey
+	copy(b, pub.k[:])
+	return &pub, nil
+}
+
+func MarshalEd25519PublicKey(k *Ed25519PublicKey) ([]byte, error) {
+	return k.Bytes()
+}

--- a/p2p/crypto/ed25519.go
+++ b/p2p/crypto/ed25519.go
@@ -6,17 +6,13 @@ import (
 	ed "github.com/mildred/ed25519/src"
 )
 
-type edPubKey [32]byte
-type edPrivKey [64]byte
-type edSeed [32]byte
+type Ed25519PublicKey struct {
+	k ed.PublicKey
+}
 
 type Ed25519PrivateKey struct {
 	sk ed.PrivateKey
 	pk ed.PublicKey
-}
-
-type Ed25519PublicKey struct {
-	k ed.PublicKey
 }
 
 func (pk *Ed25519PublicKey) Verify(data, sig []byte) (bool, error) {
@@ -38,22 +34,7 @@ func (pk *Ed25519PublicKey) Equals(k Key) bool {
 }
 
 func (pk *Ed25519PublicKey) Hash() ([]byte, error) {
-	return pk.k[:], nil
-}
-
-func (pk *Ed25519PublicKey) Encrypt(data []byte) ([]byte, error) {
-	var empty []byte
-	return empty, errors.New("Cannot encrypt not knowing a private key")
-}
-
-func (pk *Ed25519PrivateKey) Decrypt(b []byte) ([]byte, error) {
-	var empty []byte
-	return empty, errors.New("Cannot decrypt not knowing the public key of the other side")
-}
-
-func (sk *Ed25519PrivateKey) GenSecret() ([]byte, error) {
-	buf, err := ed.CreateSeed()
-	return buf[:], err
+	return KeyHash(pk)
 }
 
 func (sk *Ed25519PrivateKey) Sign(message []byte) ([]byte, error) {

--- a/p2p/crypto/internal/pb/Makefile
+++ b/p2p/crypto/internal/pb/Makefile
@@ -1,10 +1,11 @@
 PB = $(wildcard *.proto)
 GO = $(PB:.proto=.pb.go)
+PROTOBUF_INCLUDE = /usr/local/opt/protobuf/include
 
 all: $(GO)
 
 %.pb.go: %.proto
-		protoc --gogo_out=. --proto_path=../../../../../../:/usr/local/opt/protobuf/include:. $<
+		protoc --gogo_out=. --proto_path=../../../../../../:$(PROTOBUF_INCLUDE):. $<
 
 clean:
 		rm *.pb.go

--- a/p2p/crypto/internal/pb/crypto.pb.go
+++ b/p2p/crypto/internal/pb/crypto.pb.go
@@ -14,7 +14,7 @@ It has these top-level messages:
 */
 package crypto_pb
 
-import proto "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/gogoprotobuf/proto"
+import proto "code.google.com/p/gogoprotobuf/proto"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -24,14 +24,17 @@ var _ = math.Inf
 type KeyType int32
 
 const (
-	KeyType_RSA KeyType = 0
+	KeyType_RSA     KeyType = 0
+	KeyType_Ed25519 KeyType = 1
 )
 
 var KeyType_name = map[int32]string{
 	0: "RSA",
+	1: "Ed25519",
 }
 var KeyType_value = map[string]int32{
-	"RSA": 0,
+	"RSA":     0,
+	"Ed25519": 1,
 }
 
 func (x KeyType) Enum() *KeyType {

--- a/p2p/crypto/internal/pb/crypto.proto
+++ b/p2p/crypto/internal/pb/crypto.proto
@@ -2,6 +2,7 @@ package crypto.pb;
 
 enum KeyType {
 	RSA = 0;
+	Ed25519 = 1;
 }
 
 message PublicKey {

--- a/p2p/crypto/key.go
+++ b/p2p/crypto/key.go
@@ -57,11 +57,6 @@ type PrivKey interface {
 
 	// Return a public key paired with this private key
 	GetPublic() PubKey
-
-	// Generate a secret string of bytes
-	GenSecret() ([]byte, error)
-
-	Decrypt(b []byte) ([]byte, error)
 }
 
 type PubKey interface {
@@ -69,9 +64,6 @@ type PubKey interface {
 
 	// Verify that 'sig' is the signed hash of 'data'
 	Verify(data []byte, sig []byte) (bool, error)
-
-	// Encrypt data in a way that can be decrypted by a paired private key
-	Encrypt(data []byte) ([]byte, error)
 }
 
 // Given a public key, generates the shared key.

--- a/p2p/crypto/key_test.go
+++ b/p2p/crypto/key_test.go
@@ -1,16 +1,27 @@
 package crypto_test
 
 import (
-	"crypto/rand"
 	. "github.com/jbenet/go-ipfs/p2p/crypto"
 
 	"bytes"
+	u "github.com/jbenet/go-ipfs/util"
 	tu "github.com/jbenet/go-ipfs/util/testutil"
 	"testing"
 )
 
 func TestRsaKeys(t *testing.T) {
-	sk, pk, err := tu.RandTestKeyPair(512)
+	sk, pk, err := tu.RandTestRSAKeyPair(512)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testKeySignature(t, sk)
+	testKeyEncoding(t, sk)
+	testKeyEquals(t, sk)
+	testKeyEquals(t, pk)
+}
+
+func TestEd25519Keys(t *testing.T) {
+	sk, pk, err := tu.RandTestEd25519KeyPair()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -22,6 +33,7 @@ func TestRsaKeys(t *testing.T) {
 
 func testKeySignature(t *testing.T, sk PrivKey) {
 	pk := sk.GetPublic()
+	rand := u.NewTimeSeededRand()
 
 	text := make([]byte, 16)
 	rand.Read(text)
@@ -37,6 +49,12 @@ func testKeySignature(t *testing.T, sk PrivKey) {
 
 	if !valid {
 		t.Fatal("Invalid signature.")
+	}
+
+	rand.Read(sig[:])
+	valid, err = pk.Verify(text, sig)
+	if valid && err == nil {
+		t.Fatal("Valid random signature.")
 	}
 }
 
@@ -95,7 +113,7 @@ func testKeyEquals(t *testing.T, k Key) {
 		t.Fatal("Key not equal to key with same bytes.")
 	}
 
-	sk, pk, err := tu.RandTestKeyPair(512)
+	sk, pk, err := tu.RandTestRSAKeyPair(512)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/p2p/crypto/key_test.go
+++ b/p2p/crypto/key_test.go
@@ -1,6 +1,7 @@
 package crypto_test
 
 import (
+	"crypto/rand"
 	. "github.com/jbenet/go-ipfs/p2p/crypto"
 
 	"bytes"
@@ -22,7 +23,8 @@ func TestRsaKeys(t *testing.T) {
 func testKeySignature(t *testing.T, sk PrivKey) {
 	pk := sk.GetPublic()
 
-	text := sk.GenSecret()
+	text := make([]byte, 16)
+	rand.Read(text)
 	sig, err := sk.Sign(text)
 	if err != nil {
 		t.Fatal(err)

--- a/p2p/crypto/rsa.go
+++ b/p2p/crypto/rsa.go
@@ -44,10 +44,6 @@ func (pk *RsaPublicKey) Bytes() ([]byte, error) {
 	return proto.Marshal(pbmes)
 }
 
-func (pk *RsaPublicKey) Encrypt(b []byte) ([]byte, error) {
-	return rsa.EncryptPKCS1v15(rand.Reader, pk.k, b)
-}
-
 // Equals checks whether this key is equal to another
 func (pk *RsaPublicKey) Equals(k Key) bool {
 	return KeyEqual(pk, k)
@@ -55,12 +51,6 @@ func (pk *RsaPublicKey) Equals(k Key) bool {
 
 func (pk *RsaPublicKey) Hash() ([]byte, error) {
 	return KeyHash(pk)
-}
-
-func (sk *RsaPrivateKey) GenSecret() ([]byte, error) {
-	buf := make([]byte, 16)
-	_, err := rand.Read(buf)
-	return buf, err
 }
 
 func (sk *RsaPrivateKey) Sign(message []byte) ([]byte, error) {
@@ -73,10 +63,6 @@ func (sk *RsaPrivateKey) GetPublic() PubKey {
 		sk.pk = &sk.sk.PublicKey
 	}
 	return &RsaPublicKey{sk.pk}
-}
-
-func (sk *RsaPrivateKey) Decrypt(b []byte) ([]byte, error) {
-	return rsa.DecryptPKCS1v15(rand.Reader, sk.sk, b)
 }
 
 func (sk *RsaPrivateKey) Bytes() ([]byte, error) {

--- a/p2p/crypto/rsa.go
+++ b/p2p/crypto/rsa.go
@@ -57,10 +57,10 @@ func (pk *RsaPublicKey) Hash() ([]byte, error) {
 	return KeyHash(pk)
 }
 
-func (sk *RsaPrivateKey) GenSecret() []byte {
+func (sk *RsaPrivateKey) GenSecret() ([]byte, error) {
 	buf := make([]byte, 16)
-	rand.Read(buf)
-	return buf
+	_, err := rand.Read(buf)
+	return buf, err
 }
 
 func (sk *RsaPrivateKey) Sign(message []byte) ([]byte, error) {

--- a/p2p/net/mock/mock_test.go
+++ b/p2p/net/mock/mock_test.go
@@ -26,15 +26,15 @@ func randPeer(t *testing.T) peer.ID {
 func TestNetworkSetup(t *testing.T) {
 
 	ctx := context.Background()
-	sk1, _, err := testutil.RandTestKeyPair(512)
+	sk1, _, err := testutil.RandTestRSAKeyPair(512)
 	if err != nil {
 		t.Fatal(t)
 	}
-	sk2, _, err := testutil.RandTestKeyPair(512)
+	sk2, _, err := testutil.RandTestRSAKeyPair(512)
 	if err != nil {
 		t.Fatal(t)
 	}
-	sk3, _, err := testutil.RandTestKeyPair(512)
+	sk3, _, err := testutil.RandTestRSAKeyPair(512)
 	if err != nil {
 		t.Fatal(t)
 	}
@@ -398,7 +398,7 @@ func TestAdding(t *testing.T) {
 
 	peers := []peer.ID{}
 	for i := 0; i < 3; i++ {
-		sk, _, err := testutil.RandTestKeyPair(512)
+		sk, _, err := testutil.RandTestRSAKeyPair(512)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/p2p/peer/peer_test.go
+++ b/p2p/peer/peer_test.go
@@ -41,7 +41,7 @@ type keyset struct {
 
 func (ks *keyset) generate() error {
 	var err error
-	ks.sk, ks.pk, err = tu.RandTestKeyPair(512)
+	ks.sk, ks.pk, err = tu.RandTestRSAKeyPair(512)
 	if err != nil {
 		return err
 	}

--- a/p2p/test/util/key.go
+++ b/p2p/test/util/key.go
@@ -46,8 +46,8 @@ func (pk TestBogusPublicKey) Hash() ([]byte, error) {
 	return ic.KeyHash(pk)
 }
 
-func (sk TestBogusPrivateKey) GenSecret() []byte {
-	return []byte(sk)
+func (sk TestBogusPrivateKey) GenSecret() ([]byte, error) {
+	return []byte(sk), nil
 }
 
 func (sk TestBogusPrivateKey) Sign(message []byte) ([]byte, error) {

--- a/util/testutil/gen.go
+++ b/util/testutil/gen.go
@@ -29,12 +29,20 @@ func init() {
 	ZeroLocalTCPAddress = maddr
 }
 
-func RandTestKeyPair(bits int) (ci.PrivKey, ci.PubKey, error) {
+func RandTestRSAKeyPair(bits int) (ci.PrivKey, ci.PubKey, error) {
 	return ci.GenerateKeyPairWithReader(ci.RSA, bits, u.NewTimeSeededRand())
 }
 
-func SeededTestKeyPair(seed int64) (ci.PrivKey, ci.PubKey, error) {
+func SeededTestRSAKeyPair(seed int64) (ci.PrivKey, ci.PubKey, error) {
 	return ci.GenerateKeyPairWithReader(ci.RSA, 512, u.NewSeededRand(seed))
+}
+
+func RandTestEd25519KeyPair() (ci.PrivKey, ci.PubKey, error) {
+	return ci.GenerateKeyPairWithReader(ci.Ed25519, 0, u.NewTimeSeededRand())
+}
+
+func SeededTestEd25519KeyPair(seed int64) (ci.PrivKey, ci.PubKey, error) {
+	return ci.GenerateKeyPairWithReader(ci.Ed25519, 0, u.NewSeededRand(seed))
 }
 
 // RandPeerID generates random "valid" peer IDs. it does not NEED to generate
@@ -142,7 +150,7 @@ func RandPeerNetParams() (*PeerNetParams, error) {
 	var p PeerNetParams
 	var err error
 	p.Addr = ZeroLocalTCPAddress
-	p.PrivKey, p.PubKey, err = RandTestKeyPair(512)
+	p.PrivKey, p.PubKey, err = RandTestRSAKeyPair(512)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request add [ed25519](http://ed25519.cr.yp.to/) support to IPNS. This probably needs some polishing. In particular, I don't understand how to implement the Encode and Decode functions (see code). I don't even see why they are useful in our context. We could leave them out completely, no one uses them.