### PR TITLE
Fix daemon initialization output change

### DIFF
--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -88,7 +88,8 @@ test_launch_ipfs_daemon() {
 
 	test_expect_success FUSE "'ipfs daemon' output looks good" '
 		IPFS_PID=$! &&
-		echo "API server listening on /ip4/127.0.0.1/tcp/5001" >expected &&
+		echo "Initializing daemon..." >expected &&
+		echo "API server listening on /ip4/127.0.0.1/tcp/5001" >>expected &&
 		test_cmp_repeat_10_sec expected actual ||
 		fsh cat daemon_err
 	'


### PR DESCRIPTION
Since commit 76d9d89aff230895dd3bb1171085eb85633fcbc3, there is
"Initializing daemon..." printed on the standard output when
the daemon is started.

This means that tests have to be fixed accordingly.

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>