### PR TITLE
Allow sharness to run daemon without FUSE

### DIFF
--- a/test/sharness/lib/test-lib.sh
+++ b/test/sharness/lib/test-lib.sh
@@ -82,11 +82,11 @@ test_init_ipfs() {
 
 test_launch_ipfs_daemon() {
 
-	test_expect_success FUSE "'ipfs daemon' succeeds" '
+	test_expect_success "'ipfs daemon' succeeds" '
 		ipfs daemon >actual 2>daemon_err &
 	'
 
-	test_expect_success FUSE "'ipfs daemon' output looks good" '
+	test_expect_success "'ipfs daemon' output looks good" '
 		IPFS_PID=$! &&
 		echo "Initializing daemon..." >expected &&
 		echo "API server listening on /ip4/127.0.0.1/tcp/5001" >>expected &&
@@ -132,11 +132,11 @@ test_kill_repeat_10_sec() {
 
 test_kill_ipfs_daemon() {
 
-	test_expect_success FUSE "'ipfs daemon' is still running" '
+	test_expect_success "'ipfs daemon' is still running" '
 		kill -0 $IPFS_PID
 	'
 
-	test_expect_success FUSE "'ipfs daemon' can be killed" '
+	test_expect_success "'ipfs daemon' can be killed" '
 		test_kill_repeat_10_sec $IPFS_PID
 	'
 }

--- a/test/sharness/t0080-repo.sh
+++ b/test/sharness/t0080-repo.sh
@@ -14,7 +14,7 @@ test_launch_ipfs_daemon
 test_expect_success "'ipfs add afile' succeeds" '
 	echo "some text" >afile
 	HASH=`ipfs add -q afile`
-	echo -n $HASH >hashfile
+	printf "$HASH" >hashfile
 '
 
 test_expect_success "added file was pinned" '
@@ -26,7 +26,7 @@ test_expect_success "'ipfs repo gc' succeeds" '
 '
 
 test_expect_success "'ipfs repo gc' looks good (empty)" '
-	echo -n "" >empty
+	printf "" >empty
 	test_cmp empty gc_out_actual
 '
 

--- a/test/sharness/t0080-repo.sh
+++ b/test/sharness/t0080-repo.sh
@@ -12,9 +12,9 @@ test_init_ipfs
 test_launch_ipfs_daemon
 
 test_expect_success "'ipfs add afile' succeeds" '
-	echo "some text" > afile
+	echo "some text" >afile
 	HASH=`ipfs add -q afile`
-	echo -n $HASH > hashfile
+	echo -n $HASH >hashfile
 '
 
 test_expect_success "added file was pinned" '
@@ -22,29 +22,29 @@ test_expect_success "added file was pinned" '
 '
 
 test_expect_success "'ipfs repo gc' succeeds" '
-	ipfs repo gc > gc_out_actual
+	ipfs repo gc >gc_out_actual
 '
 
 test_expect_success "'ipfs repo gc' looks good (empty)" '
-	echo -n "" > empty
+	echo -n "" >empty
 	test_cmp empty gc_out_actual
 '
 
 test_expect_success "'ipfs repo gc' doesnt remove file" '
-	ipfs cat $HASH > out
+	ipfs cat $HASH >out
 	test_cmp out afile
 '
 
 test_expect_success "'ipfs pin rm' succeeds" '
-	echo unpinned $HASH > expected1
-	ipfs pin rm -r $HASH > actual1
+	echo unpinned $HASH >expected1
+	ipfs pin rm -r $HASH >actual1
 	test_cmp expected1 actual1
 '
 
 test_expect_success "file no longer pinned" '
 	# we expect the welcome file to show up here
-	echo QmTTFXiXoixwT53tcGPu419udsHEHYu6AHrQC8HAKdJYaZ > expected2
-	ipfs pin ls -type=recursive > actual2
+	echo QmTTFXiXoixwT53tcGPu419udsHEHYu6AHrQC8HAKdJYaZ >expected2
+	ipfs pin ls -type=recursive >actual2
 	test_cmp expected2 actual2
 '
 
@@ -53,88 +53,88 @@ test_expect_success "recursively pin afile" '
 '
 
 test_expect_success "pinning directly should fail now" '
-	echo Error: pin: $HASH already pinned recursively > expected3
-	ipfs pin add $HASH 2> actual3
+	echo Error: pin: $HASH already pinned recursively >expected3
+	ipfs pin add $HASH 2>actual3
 	test_cmp expected3 actual3
 '
 
 test_expect_success "'ipfs pin rm <hash>' should fail" '
-	echo Error: $HASH is pinned recursively > expected4
-	ipfs pin rm $HASH 2> actual4
+	echo Error: $HASH is pinned recursively >expected4
+	ipfs pin rm $HASH 2>actual4
 	test_cmp expected4 actual4
 '
 
 test_expect_success "remove recursive pin, add direct" '
-	echo unpinned $HASH > expected5
-	ipfs pin rm -r $HASH > actual5
+	echo unpinned $HASH >expected5
+	ipfs pin rm -r $HASH >actual5
 	test_cmp expected5 actual5
 	ipfs pin add $HASH
 '
 
 test_expect_success "remove direct pin" '
-	echo unpinned $HASH > expected6
-	ipfs pin rm $HASH > actual6
+	echo unpinned $HASH >expected6
+	ipfs pin rm $HASH >actual6
 	test_cmp expected6 actual6
 '
 
 test_expect_success "'ipfs repo gc' removes file" '
-	echo removed $HASH > expected7
-	ipfs repo gc > actual7
+	echo removed $HASH >expected7
+	ipfs repo gc >actual7
 	test_cmp expected7 actual7
 '
 
 test_expect_success "'ipfs refs local' no longer shows file" '
-	echo QmTTFXiXoixwT53tcGPu419udsHEHYu6AHrQC8HAKdJYaZ > expected8
-	echo QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn >> expected8
-	ipfs refs local > actual8
+	echo QmTTFXiXoixwT53tcGPu419udsHEHYu6AHrQC8HAKdJYaZ >expected8
+	echo QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn >>expected8
+	ipfs refs local >actual8
 	test_cmp expected8 actual8
 '
 
 test_expect_success "adding multiblock random file succeeds" '
-	random 1000000 > multiblock
+	random 1000000 >multiblock
 	MBLOCKHASH=`ipfs add -q multiblock`
 '
 
 test_expect_success "'ipfs pin ls -type=indirect' is correct" '
-	ipfs refs $MBLOCKHASH | sort > refsout
-	ipfs pin ls -type=indirect | sort > indirectpins
+	ipfs refs $MBLOCKHASH | sort >refsout
+	ipfs pin ls -type=indirect | sort >indirectpins
 	test_cmp refsout indirectpins
 '
 
 test_expect_success "pin something directly" '
-	echo "ipfs is so awesome" > awesome
+	echo "ipfs is so awesome" >awesome
 	DIRECTPIN=`ipfs add -q awesome`
-	echo unpinned $DIRECTPIN > expected9
-	ipfs pin rm -r $DIRECTPIN > actual9
+	echo unpinned $DIRECTPIN >expected9
+	ipfs pin rm -r $DIRECTPIN >actual9
 	test_cmp expected9 actual9
 
-	echo pinned $DIRECTPIN directly > expected10
-	ipfs pin add $DIRECTPIN > actual10
+	echo pinned $DIRECTPIN directly >expected10
+	ipfs pin add $DIRECTPIN >actual10
 	test_cmp expected10 actual10
 '
 
 test_expect_success "'ipfs pin ls -type=direct' is correct" '
-	echo $DIRECTPIN > directpinexpected
-	echo QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn >> directpinexpected
-	cat directpinexpected | sort > dp_exp_sorted
-	ipfs pin ls -type=direct | sort > directpinout
+	echo $DIRECTPIN >directpinexpected
+	echo QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn >>directpinexpected
+	cat directpinexpected | sort >dp_exp_sorted
+	ipfs pin ls -type=direct | sort >directpinout
 	test_cmp dp_exp_sorted directpinout
 '
 
 test_expect_success "'ipfs pin ls -type=recursive' is correct" '
-	echo $MBLOCKHASH > rp_expected
-	echo QmTTFXiXoixwT53tcGPu419udsHEHYu6AHrQC8HAKdJYaZ >> rp_expected
-	cat rp_expected | sort > rp_exp_sorted
-	ipfs pin ls -type=recursive | sort > rp_actual
+	echo $MBLOCKHASH >rp_expected
+	echo QmTTFXiXoixwT53tcGPu419udsHEHYu6AHrQC8HAKdJYaZ >>rp_expected
+	cat rp_expected | sort >rp_exp_sorted
+	ipfs pin ls -type=recursive | sort >rp_actual
 	test_cmp rp_exp_sorted rp_actual
 '
 
 test_expect_success "'ipfs pin ls -type=all' is correct" '
-	cat directpinout > allpins
-	cat rp_actual >> allpins
-	cat indirectpins >> allpins
-	cat allpins | sort > allpins_sorted
-	ipfs pin ls -type=all | sort > actual_allpins
+	cat directpinout >allpins
+	cat rp_actual >>allpins
+	cat indirectpins >>allpins
+	cat allpins | sort >allpins_sorted
+	ipfs pin ls -type=all | sort >actual_allpins
 	test_cmp allpins_sorted actual_allpins
 '
 

--- a/test/sharness/t0080-repo.sh
+++ b/test/sharness/t0080-repo.sh
@@ -18,7 +18,7 @@ test_expect_success "'ipfs add afile' succeeds" '
 '
 
 test_expect_success "added file was pinned" '
-	ipfs pin ls -type=recursive | grep $HASH
+	ipfs pin ls -type=recursive | grep "$HASH"
 '
 
 test_expect_success "'ipfs repo gc' succeeds" '
@@ -31,13 +31,13 @@ test_expect_success "'ipfs repo gc' looks good (empty)" '
 '
 
 test_expect_success "'ipfs repo gc' doesnt remove file" '
-	ipfs cat $HASH >out
+	ipfs cat "$HASH" >out
 	test_cmp out afile
 '
 
 test_expect_success "'ipfs pin rm' succeeds" '
-	echo unpinned $HASH >expected1
-	ipfs pin rm -r $HASH >actual1
+	echo "unpinned $HASH" >expected1
+	ipfs pin rm -r "$HASH" >actual1
 	test_cmp expected1 actual1
 '
 
@@ -49,36 +49,36 @@ test_expect_success "file no longer pinned" '
 '
 
 test_expect_success "recursively pin afile" '
-	ipfs pin add -r $HASH
+	ipfs pin add -r "$HASH"
 '
 
 test_expect_success "pinning directly should fail now" '
-	echo Error: pin: $HASH already pinned recursively >expected3
-	ipfs pin add $HASH 2>actual3
+	echo "Error: pin: $HASH already pinned recursively" >expected3
+	ipfs pin add "$HASH" 2>actual3
 	test_cmp expected3 actual3
 '
 
 test_expect_success "'ipfs pin rm <hash>' should fail" '
-	echo Error: $HASH is pinned recursively >expected4
-	ipfs pin rm $HASH 2>actual4
+	echo "Error: $HASH is pinned recursively" >expected4
+	ipfs pin rm "$HASH" 2>actual4
 	test_cmp expected4 actual4
 '
 
 test_expect_success "remove recursive pin, add direct" '
-	echo unpinned $HASH >expected5
-	ipfs pin rm -r $HASH >actual5
+	echo "unpinned $HASH" >expected5
+	ipfs pin rm -r "$HASH" >actual5
 	test_cmp expected5 actual5
-	ipfs pin add $HASH
+	ipfs pin add "$HASH"
 '
 
 test_expect_success "remove direct pin" '
-	echo unpinned $HASH >expected6
-	ipfs pin rm $HASH >actual6
+	echo "unpinned $HASH" >expected6
+	ipfs pin rm "$HASH" >actual6
 	test_cmp expected6 actual6
 '
 
 test_expect_success "'ipfs repo gc' removes file" '
-	echo removed $HASH >expected7
+	echo "removed $HASH" >expected7
 	ipfs repo gc >actual7
 	test_cmp expected7 actual7
 '
@@ -96,7 +96,7 @@ test_expect_success "adding multiblock random file succeeds" '
 '
 
 test_expect_success "'ipfs pin ls -type=indirect' is correct" '
-	ipfs refs $MBLOCKHASH | sort >refsout
+	ipfs refs "$MBLOCKHASH" | sort >refsout
 	ipfs pin ls -type=indirect | sort >indirectpins
 	test_cmp refsout indirectpins
 '
@@ -104,17 +104,17 @@ test_expect_success "'ipfs pin ls -type=indirect' is correct" '
 test_expect_success "pin something directly" '
 	echo "ipfs is so awesome" >awesome
 	DIRECTPIN=`ipfs add -q awesome`
-	echo unpinned $DIRECTPIN >expected9
-	ipfs pin rm -r $DIRECTPIN >actual9
+	echo "unpinned $DIRECTPIN" >expected9
+	ipfs pin rm -r "$DIRECTPIN" >actual9
 	test_cmp expected9 actual9
 
-	echo pinned $DIRECTPIN directly >expected10
-	ipfs pin add $DIRECTPIN >actual10
+	echo "pinned $DIRECTPIN directly" >expected10
+	ipfs pin add "$DIRECTPIN" >actual10
 	test_cmp expected10 actual10
 '
 
 test_expect_success "'ipfs pin ls -type=direct' is correct" '
-	echo $DIRECTPIN >directpinexpected
+	echo "$DIRECTPIN" >directpinexpected
 	echo QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn >>directpinexpected
 	cat directpinexpected | sort >dp_exp_sorted
 	ipfs pin ls -type=direct | sort >directpinout
@@ -122,7 +122,7 @@ test_expect_success "'ipfs pin ls -type=direct' is correct" '
 '
 
 test_expect_success "'ipfs pin ls -type=recursive' is correct" '
-	echo $MBLOCKHASH >rp_expected
+	echo "$MBLOCKHASH" >rp_expected
 	echo QmTTFXiXoixwT53tcGPu419udsHEHYu6AHrQC8HAKdJYaZ >>rp_expected
 	cat rp_expected | sort >rp_exp_sorted
 	ipfs pin ls -type=recursive | sort >rp_actual

--- a/test/sharness/t0090-get.sh
+++ b/test/sharness/t0090-get.sh
@@ -46,7 +46,7 @@ test_expect_success "ipfs get -a succeeds" '
 '
 
 test_expect_success "ipfs get -a output looks good" '
-  echo "Saving archive to "$HASH".tar
+  echo "Saving archive to $HASH.tar
 " >expected &&
   test_cmp expected actual
 '
@@ -63,7 +63,7 @@ test_expect_success "ipfs get -a -C succeeds" '
 '
 
 test_expect_success "ipfs get -a -C output looks good" '
-  echo "Saving archive to "$HASH".tar.gz
+  echo "Saving archive to $HASH.tar.gz
 " >expected &&
   test_cmp expected actual
 '
@@ -85,7 +85,7 @@ test_expect_success "ipfs get succeeds (directory)" '
 '
 
 test_expect_success "ipfs get output looks good (directory)" '
-  echo "Saving file(s) to "$HASH2"
+  echo "Saving file(s) to $HASH2
 " >expected &&
   test_cmp expected actual
 '
@@ -101,7 +101,7 @@ test_expect_success "ipfs get -a -C succeeds (directory)" '
 '
 
 test_expect_success "ipfs get -a -C output looks good (directory)" '
-  echo "Saving archive to "$HASH2".tar.gz
+  echo "Saving archive to $HASH2.tar.gz
 " >expected &&
   test_cmp expected actual
 '

--- a/test/sharness/t0090-get.sh
+++ b/test/sharness/t0090-get.sh
@@ -12,23 +12,23 @@ test_init_ipfs
 test_launch_ipfs_daemon
 
 test_expect_success "'ipfs get --help' succeeds" '
-  ipfs get --help > actual
+  ipfs get --help >actual
 '
 
 test_expect_success "'ipfs get --help' output looks good" '
-  egrep "ipfs get.*<ipfs-path>" actual > /dev/null ||
+  egrep "ipfs get.*<ipfs-path>" actual >/dev/null ||
   fsh cat actual
 '
 
 test_expect_success "ipfs get succeeds" '
-  echo "Hello Worlds!" > data &&
+  echo "Hello Worlds!" >data &&
   HASH=`ipfs add -q data` &&
-  ipfs get "$HASH" > actual
+  ipfs get "$HASH" >actual
 '
 
 test_expect_success "ipfs get output looks good" '
   echo "Saving file(s) to "$HASH"
-" > expected &&
+" >expected &&
   test_cmp expected actual
 '
 
@@ -37,17 +37,17 @@ test_expect_success "ipfs get file output looks good" '
 '
 
 test_expect_success "ipfs get errors when trying to overwrite a file" '
-  test_must_fail ipfs get "$HASH" > actual &&
+  test_must_fail ipfs get "$HASH" >actual &&
   rm "$HASH"
 '
 
 test_expect_success "ipfs get -a succeeds" '
-  ipfs get "$HASH" -a > actual
+  ipfs get "$HASH" -a >actual
 '
 
 test_expect_success "ipfs get -a output looks good" '
   echo "Saving archive to "$HASH".tar
-" > expected &&
+" >expected &&
   test_cmp expected actual
 '
 
@@ -59,12 +59,12 @@ test_expect_success "ipfs get -a archive output is valid" '
 '
 
 test_expect_success "ipfs get -a -C succeeds" '
-  ipfs get "$HASH" -a -C > actual
+  ipfs get "$HASH" -a -C >actual
 '
 
 test_expect_success "ipfs get -a -C output looks good" '
   echo "Saving archive to "$HASH".tar.gz
-" > expected &&
+" >expected &&
   test_cmp expected actual
 '
 
@@ -79,14 +79,14 @@ test_expect_success "ipfs get succeeds (directory)" '
   mkdir dir &&
   touch dir/a &&
   mkdir dir/b &&
-  echo "Hello, Worlds!" > dir/b/c &&
+  echo "Hello, Worlds!" >dir/b/c &&
   HASH2=`ipfs add -r -q dir | tail -n 1` &&
-  ipfs get "$HASH2" > actual
+  ipfs get "$HASH2" >actual
 '
 
 test_expect_success "ipfs get output looks good (directory)" '
   echo "Saving file(s) to "$HASH2"
-" > expected &&
+" >expected &&
   test_cmp expected actual
 '
 
@@ -97,12 +97,12 @@ test_expect_success "ipfs get output is valid (directory)" '
 '
 
 test_expect_success "ipfs get -a -C succeeds (directory)" '
-  ipfs get "$HASH2" -a -C > actual
+  ipfs get "$HASH2" -a -C >actual
 '
 
 test_expect_success "ipfs get -a -C output looks good (directory)" '
   echo "Saving archive to "$HASH2".tar.gz
-" > expected &&
+" >expected &&
   test_cmp expected actual
 '
 


### PR DESCRIPTION
This PR allows sharness tests to run daemon tests when the
FUSE option is off. Unsure why this was previously included,
I'm likley missing something, which I will find out if travis
fails now.

I included some general fixes, too:
- use `>file` not `> file`
- **_always_** make sure variables are in quotes. `"$HASH"`

Also:
- @whyrusleeping: were not escaping.
- @mappum: were accidentally unescaping. check it out.
- @mappum: this _may_ fix your tar problem.