### PR TITLE
implement path type

### DIFF
--- a/core/commands/cat.go
+++ b/core/commands/cat.go
@@ -5,6 +5,7 @@ import (
 
 	cmds "github.com/jbenet/go-ipfs/commands"
 	core "github.com/jbenet/go-ipfs/core"
+	path "github.com/jbenet/go-ipfs/path"
 	uio "github.com/jbenet/go-ipfs/unixfs/io"
 
 	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/cheggaaa/pb"
@@ -61,8 +62,8 @@ it contains.
 func cat(node *core.IpfsNode, paths []string) ([]io.Reader, uint64, error) {
 	readers := make([]io.Reader, 0, len(paths))
 	length := uint64(0)
-	for _, path := range paths {
-		dagnode, err := node.Resolver.ResolvePath(path)
+	for _, fpath := range paths {
+		dagnode, err := node.Resolver.ResolvePath(path.Path(fpath))
 		if err != nil {
 			return nil, 0, err
 		}

--- a/core/commands/get.go
+++ b/core/commands/get.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
+	gopath "path"
 	"strings"
 
 	cmds "github.com/jbenet/go-ipfs/commands"
 	core "github.com/jbenet/go-ipfs/core"
+	path "github.com/jbenet/go-ipfs/path"
 	tar "github.com/jbenet/go-ipfs/thirdparty/tar"
 	utar "github.com/jbenet/go-ipfs/unixfs/tar"
 
@@ -77,8 +78,8 @@ may also specify the level of compression by specifying '-l=<1-9>'.
 
 		outPath, _, _ := req.Option("output").String()
 		if len(outPath) == 0 {
-			_, outPath = path.Split(req.Arguments()[0])
-			outPath = path.Clean(outPath)
+			_, outPath = gopath.Split(req.Arguments()[0])
+			outPath = gopath.Clean(outPath)
 		}
 
 		cmplvl, err := getCompressOptions(req)
@@ -165,5 +166,5 @@ func getCompressOptions(req cmds.Request) (int, error) {
 }
 
 func get(node *core.IpfsNode, p string, compression int) (io.Reader, error) {
-	return utar.NewReader(p, node.DAG, node.Resolver, compression)
+	return utar.NewReader(path.Path(p), node.DAG, node.Resolver, compression)
 }

--- a/core/commands/ls.go
+++ b/core/commands/ls.go
@@ -7,6 +7,7 @@ import (
 
 	cmds "github.com/jbenet/go-ipfs/commands"
 	merkledag "github.com/jbenet/go-ipfs/merkledag"
+	path "github.com/jbenet/go-ipfs/path"
 )
 
 type Link struct {
@@ -47,8 +48,8 @@ it contains, with the following format:
 		paths := req.Arguments()
 
 		dagnodes := make([]*merkledag.Node, 0)
-		for _, path := range paths {
-			dagnode, err := node.Resolver.ResolvePath(path)
+		for _, fpath := range paths {
+			dagnode, err := node.Resolver.ResolvePath(path.Path(fpath))
 			if err != nil {
 				res.SetError(err, cmds.ErrNormal)
 				return

--- a/core/commands/object.go
+++ b/core/commands/object.go
@@ -14,6 +14,7 @@ import (
 	cmds "github.com/jbenet/go-ipfs/commands"
 	core "github.com/jbenet/go-ipfs/core"
 	dag "github.com/jbenet/go-ipfs/merkledag"
+	path "github.com/jbenet/go-ipfs/path"
 )
 
 // ErrObjectTooLarge is returned when too much data was read from stdin. current limit 512k
@@ -78,8 +79,8 @@ output is the raw data of the object.
 			return
 		}
 
-		key := req.Arguments()[0]
-		output, err := objectData(n, key)
+		fpath := path.Path(req.Arguments()[0])
+		output, err := objectData(n, fpath)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return
@@ -108,8 +109,8 @@ multihash.
 			return
 		}
 
-		key := req.Arguments()[0]
-		output, err := objectLinks(n, key)
+		fpath := path.Path(req.Arguments()[0])
+		output, err := objectLinks(n, fpath)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return
@@ -156,9 +157,9 @@ This command outputs data in the following encodings:
 			return
 		}
 
-		key := req.Arguments()[0]
+		fpath := path.Path(req.Arguments()[0])
 
-		object, err := objectGet(n, key)
+		object, err := objectGet(n, fpath)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return
@@ -222,9 +223,9 @@ var objectStatCmd = &cmds.Command{
 			return
 		}
 
-		key := req.Arguments()[0]
+		fpath := path.Path(req.Arguments()[0])
 
-		object, err := objectGet(n, key)
+		object, err := objectGet(n, fpath)
 		if err != nil {
 			res.SetError(err, cmds.ErrNormal)
 			return
@@ -317,37 +318,37 @@ Data should be in the format specified by <encoding>.
 }
 
 // objectData takes a key string and writes out the raw bytes of that node (if there is one)
-func objectData(n *core.IpfsNode, key string) (io.Reader, error) {
-	dagnode, err := n.Resolver.ResolvePath(key)
+func objectData(n *core.IpfsNode, fpath path.Path) (io.Reader, error) {
+	dagnode, err := n.Resolver.ResolvePath(fpath)
 	if err != nil {
 		return nil, err
 	}
 
-	log.Debugf("objectData: found dagnode %q (# of bytes: %d - # links: %d)", key, len(dagnode.Data), len(dagnode.Links))
+	log.Debugf("objectData: found dagnode %s (# of bytes: %d - # links: %d)", fpath, len(dagnode.Data), len(dagnode.Links))
 
 	return bytes.NewReader(dagnode.Data), nil
 }
 
 // objectLinks takes a key string and lists the links it points to
-func objectLinks(n *core.IpfsNode, key string) (*Object, error) {
-	dagnode, err := n.Resolver.ResolvePath(key)
+func objectLinks(n *core.IpfsNode, fpath path.Path) (*Object, error) {
+	dagnode, err := n.Resolver.ResolvePath(fpath)
 	if err != nil {
 		return nil, err
 	}
 
-	log.Debugf("objectLinks: found dagnode %q (# of bytes: %d - # links: %d)", key, len(dagnode.Data), len(dagnode.Links))
+	log.Debugf("objectLinks: found dagnode %s (# of bytes: %d - # links: %d)", fpath, len(dagnode.Data), len(dagnode.Links))
 
 	return getOutput(dagnode)
 }
 
 // objectGet takes a key string from args and a format option and serializes the dagnode to that format
-func objectGet(n *core.IpfsNode, key string) (*dag.Node, error) {
-	dagnode, err := n.Resolver.ResolvePath(key)
+func objectGet(n *core.IpfsNode, fpath path.Path) (*dag.Node, error) {
+	dagnode, err := n.Resolver.ResolvePath(fpath)
 	if err != nil {
 		return nil, err
 	}
 
-	log.Debugf("objectGet: found dagnode %q (# of bytes: %d - # links: %d)", key, len(dagnode.Data), len(dagnode.Links))
+	log.Debugf("objectGet: found dagnode %s (# of bytes: %d - # links: %d)", fpath, len(dagnode.Data), len(dagnode.Links))
 
 	return dagnode, nil
 }

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -11,6 +11,7 @@ import (
 	cmds "github.com/jbenet/go-ipfs/commands"
 	"github.com/jbenet/go-ipfs/core"
 	dag "github.com/jbenet/go-ipfs/merkledag"
+	path "github.com/jbenet/go-ipfs/path"
 	u "github.com/jbenet/go-ipfs/util"
 )
 
@@ -166,7 +167,7 @@ Displays the hashes of all local objects.
 func objectsForPaths(n *core.IpfsNode, paths []string) ([]*dag.Node, error) {
 	objects := make([]*dag.Node, len(paths))
 	for i, p := range paths {
-		o, err := n.Resolver.ResolvePath(p)
+		o, err := n.Resolver.ResolvePath(path.Path(p))
 		if err != nil {
 			return nil, err
 		}

--- a/core/core.go
+++ b/core/core.go
@@ -286,8 +286,8 @@ func (n *IpfsNode) OnlineMode() bool {
 	}
 }
 
-func (n *IpfsNode) Resolve(path string) (*merkledag.Node, error) {
-	return n.Resolver.ResolvePath(path)
+func (n *IpfsNode) Resolve(fpath string) (*merkledag.Node, error) {
+	return n.Resolver.ResolvePath(path.Path(fpath))
 }
 
 func (n *IpfsNode) Bootstrap(cfg BootstrapConfig) error {

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -4,7 +4,7 @@ import (
 	"html/template"
 	"io"
 	"net/http"
-	"path"
+	gopath "path"
 	"strings"
 	"time"
 
@@ -15,6 +15,7 @@ import (
 	"github.com/jbenet/go-ipfs/importer"
 	chunk "github.com/jbenet/go-ipfs/importer/chunk"
 	dag "github.com/jbenet/go-ipfs/merkledag"
+	path "github.com/jbenet/go-ipfs/path"
 	"github.com/jbenet/go-ipfs/routing"
 	uio "github.com/jbenet/go-ipfs/unixfs/io"
 	u "github.com/jbenet/go-ipfs/util"
@@ -71,7 +72,7 @@ func (i *gatewayHandler) loadTemplate() error {
 }
 
 func (i *gatewayHandler) ResolvePath(ctx context.Context, p string) (*dag.Node, string, error) {
-	p = path.Clean(p)
+	p = gopath.Clean(p)
 
 	if strings.HasPrefix(p, IpnsPathPrefix) {
 		elements := strings.Split(p[len(IpnsPathPrefix):], "/")
@@ -82,13 +83,13 @@ func (i *gatewayHandler) ResolvePath(ctx context.Context, p string) (*dag.Node, 
 		}
 
 		elements[0] = k.Pretty()
-		p = path.Join(elements...)
+		p = gopath.Join(elements...)
 	}
 	if !strings.HasPrefix(p, IpfsPathPrefix) {
-		p = path.Join(IpfsPathPrefix, p)
+		p = gopath.Join(IpfsPathPrefix, p)
 	}
 
-	node, err := i.node.Resolver.ResolvePath(p)
+	node, err := i.node.Resolver.ResolvePath(path.Path(p))
 	if err != nil {
 		return nil, "", err
 	}
@@ -129,7 +130,7 @@ func (i *gatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	etag := path.Base(p)
+	etag := gopath.Base(p)
 	if r.Header.Get("If-None-Match") == etag {
 		w.WriteHeader(http.StatusNotModified)
 		return
@@ -151,7 +152,7 @@ func (i *gatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if err == nil {
 		defer dr.Close()
-		_, name := path.Split(urlPath)
+		_, name := gopath.Split(urlPath)
 		// set modtime to a really long time ago, since files are immutable and should stay cached
 		modtime := time.Unix(1, 0)
 		http.ServeContent(w, r, name, modtime, dr)
@@ -188,7 +189,7 @@ func (i *gatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 
-		di := directoryItem{link.Size, link.Name, path.Join(urlPath, link.Name)}
+		di := directoryItem{link.Size, link.Name, gopath.Join(urlPath, link.Name)}
 		dirListing = append(dirListing, di)
 	}
 

--- a/core/corerepo/pinning.go
+++ b/core/corerepo/pinning.go
@@ -5,14 +5,15 @@ import (
 
 	"github.com/jbenet/go-ipfs/core"
 	"github.com/jbenet/go-ipfs/merkledag"
+	path "github.com/jbenet/go-ipfs/path"
 	u "github.com/jbenet/go-ipfs/util"
 )
 
 func Pin(n *core.IpfsNode, paths []string, recursive bool) ([]u.Key, error) {
 
 	dagnodes := make([]*merkledag.Node, 0)
-	for _, path := range paths {
-		dagnode, err := n.Resolver.ResolvePath(path)
+	for _, fpath := range paths {
+		dagnode, err := n.Resolver.ResolvePath(path.Path(fpath))
 		if err != nil {
 			return nil, fmt.Errorf("pin: %s", err)
 		}
@@ -44,8 +45,8 @@ func Pin(n *core.IpfsNode, paths []string, recursive bool) ([]u.Key, error) {
 func Unpin(n *core.IpfsNode, paths []string, recursive bool) ([]u.Key, error) {
 
 	dagnodes := make([]*merkledag.Node, 0)
-	for _, path := range paths {
-		dagnode, err := n.Resolver.ResolvePath(path)
+	for _, fpath := range paths {
+		dagnode, err := n.Resolver.ResolvePath(path.Path(fpath))
 		if err != nil {
 			return nil, err
 		}

--- a/core/coreunix/cat.go
+++ b/core/coreunix/cat.go
@@ -4,11 +4,12 @@ import (
 	"io"
 
 	core "github.com/jbenet/go-ipfs/core"
+	path "github.com/jbenet/go-ipfs/path"
 	uio "github.com/jbenet/go-ipfs/unixfs/io"
 )
 
-func Cat(n *core.IpfsNode, path string) (io.Reader, error) {
-	dagNode, err := n.Resolver.ResolvePath(path)
+func Cat(n *core.IpfsNode, p path.Path) (io.Reader, error) {
+	dagNode, err := n.Resolver.ResolvePath(p)
 	if err != nil {
 		return nil, err
 	}

--- a/fuse/ipns/ipns_unix.go
+++ b/fuse/ipns/ipns_unix.go
@@ -19,6 +19,7 @@ import (
 	mdag "github.com/jbenet/go-ipfs/merkledag"
 	nsys "github.com/jbenet/go-ipfs/namesys"
 	ci "github.com/jbenet/go-ipfs/p2p/crypto"
+	path "github.com/jbenet/go-ipfs/path"
 	ft "github.com/jbenet/go-ipfs/unixfs"
 	uio "github.com/jbenet/go-ipfs/unixfs/io"
 	ftpb "github.com/jbenet/go-ipfs/unixfs/pb"
@@ -129,7 +130,7 @@ func CreateRoot(n *core.IpfsNode, keys []ci.PrivKey, ipfsroot string) (*Root, er
 			return nil, nil
 		}
 
-		node, err := n.Resolver.ResolvePath(pointsTo.B58String())
+		node, err := n.Resolver.ResolvePath(path.Path(pointsTo.B58String()))
 		if err != nil {
 			log.Warning("Failed to resolve value from ipns entry in ipfs")
 			continue

--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -15,6 +15,7 @@ import (
 
 	core "github.com/jbenet/go-ipfs/core"
 	mdag "github.com/jbenet/go-ipfs/merkledag"
+	path "github.com/jbenet/go-ipfs/path"
 	uio "github.com/jbenet/go-ipfs/unixfs/io"
 	ftpb "github.com/jbenet/go-ipfs/unixfs/pb"
 	u "github.com/jbenet/go-ipfs/util"
@@ -56,7 +57,7 @@ func (s *Root) Lookup(name string, intr fs.Intr) (fs.Node, fuse.Error) {
 		return nil, fuse.ENOENT
 	}
 
-	nd, err := s.Ipfs.Resolver.ResolvePath(name)
+	nd, err := s.Ipfs.Resolver.ResolvePath(path.Path(name))
 	if err != nil {
 		// todo: make this error more versatile.
 		return nil, fuse.ENOENT

--- a/path/path.go
+++ b/path/path.go
@@ -1,104 +1,26 @@
-// package path implements utilities for resolving paths within ipfs.
 package path
 
 import (
-	"fmt"
 	"path"
 	"strings"
-
-	mh "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
-	merkledag "github.com/jbenet/go-ipfs/merkledag"
-	u "github.com/jbenet/go-ipfs/util"
 )
 
-var log = u.Logger("path")
+// TODO: debate making this a private struct wrapped in a public interface
+// would allow us to control creation, and cache segments.
+type Path string
 
-// Resolver provides path resolution to IPFS
-// It has a pointer to a DAGService, which is uses to resolve nodes.
-type Resolver struct {
-	DAG merkledag.DAGService
+func (p Path) Segments() []string {
+	cleaned := path.Clean(string(p))
+	segments := strings.Split(cleaned, "/")
+
+	// Ignore leading slash
+	if len(segments[0]) == 0 {
+		segments = segments[1:]
+	}
+
+	return segments
 }
 
-// ResolvePath fetches the node for given path. It uses the first
-// path component as a hash (key) of the first node, then resolves
-// all other components walking the links, with ResolveLinks.
-func (s *Resolver) ResolvePath(fpath string) (*merkledag.Node, error) {
-	log.Debugf("Resolve: '%s'", fpath)
-	fpath = path.Clean(fpath)
-
-	if strings.HasPrefix(fpath, "/ipfs/") {
-		fpath = fpath[6:]
-	}
-
-	parts := strings.Split(fpath, "/")
-
-	// skip over empty first elem
-	if len(parts[0]) == 0 {
-		parts = parts[1:]
-	}
-
-	// if nothing, bail.
-	if len(parts) == 0 {
-		return nil, fmt.Errorf("ipfs path must contain at least one component")
-	}
-
-	// first element in the path is a b58 hash (for now)
-	h, err := mh.FromB58String(parts[0])
-	if err != nil {
-		log.Debug("given path element is not a base58 string.\n")
-		return nil, err
-	}
-
-	log.Debug("Resolve dag get.\n")
-	nd, err := s.DAG.Get(u.Key(h))
-	if err != nil {
-		return nil, err
-	}
-
-	return s.ResolveLinks(nd, parts[1:])
-}
-
-// ResolveLinks iteratively resolves names by walking the link hierarchy.
-// Every node is fetched from the DAGService, resolving the next name.
-// Returns the last node found.
-//
-// ResolveLinks(nd, []string{"foo", "bar", "baz"})
-// would retrieve "baz" in ("bar" in ("foo" in nd.Links).Links).Links
-func (s *Resolver) ResolveLinks(ndd *merkledag.Node, names []string) (
-	nd *merkledag.Node, err error) {
-
-	nd = ndd // dup arg workaround
-
-	// for each of the path components
-	for _, name := range names {
-
-		var next u.Key
-		var nlink *merkledag.Link
-		// for each of the links in nd, the current object
-		for _, link := range nd.Links {
-			if link.Name == name {
-				next = u.Key(link.Hash)
-				nlink = link
-				break
-			}
-		}
-
-		if next == "" {
-			h1, _ := nd.Multihash()
-			h2 := h1.B58String()
-			return nil, fmt.Errorf("no link named %q under %s", name, h2)
-		}
-
-		if nlink.Node == nil {
-			// fetch object for link and assign to nd
-			nd, err = s.DAG.Get(next)
-			if err != nil {
-				return nd, err
-			}
-			nlink.Node = nd
-		} else {
-			nd = nlink.Node
-		}
-	}
-	return
+func (p Path) String() string {
+	return string(p)
 }

--- a/path/resolver.go
+++ b/path/resolver.go
@@ -1,0 +1,95 @@
+// package path implements utilities for resolving paths within ipfs.
+package path
+
+import (
+	"fmt"
+
+	mh "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
+	merkledag "github.com/jbenet/go-ipfs/merkledag"
+	u "github.com/jbenet/go-ipfs/util"
+)
+
+var log = u.Logger("path")
+
+// Resolver provides path resolution to IPFS
+// It has a pointer to a DAGService, which is uses to resolve nodes.
+type Resolver struct {
+	DAG merkledag.DAGService
+}
+
+// ResolvePath fetches the node for given path. It uses the first
+// path component as a hash (key) of the first node, then resolves
+// all other components walking the links, with ResolveLinks.
+func (s *Resolver) ResolvePath(fpath Path) (*merkledag.Node, error) {
+	log.Debugf("Resolve: '%s'", fpath)
+
+	parts := fpath.Segments()
+	if parts[0] == "ipfs" {
+		parts = parts[1:]
+	}
+
+	// if nothing, bail.
+	if len(parts) == 0 {
+		return nil, fmt.Errorf("ipfs path must contain at least one component")
+	}
+
+	// first element in the path is a b58 hash (for now)
+	h, err := mh.FromB58String(parts[0])
+	if err != nil {
+		log.Debug("given path element is not a base58 string.\n")
+		return nil, err
+	}
+
+	log.Debug("Resolve dag get.\n")
+	nd, err := s.DAG.Get(u.Key(h))
+	if err != nil {
+		return nil, err
+	}
+
+	return s.ResolveLinks(nd, parts[1:])
+}
+
+// ResolveLinks iteratively resolves names by walking the link hierarchy.
+// Every node is fetched from the DAGService, resolving the next name.
+// Returns the last node found.
+//
+// ResolveLinks(nd, []string{"foo", "bar", "baz"})
+// would retrieve "baz" in ("bar" in ("foo" in nd.Links).Links).Links
+func (s *Resolver) ResolveLinks(ndd *merkledag.Node, names []string) (
+	nd *merkledag.Node, err error) {
+
+	nd = ndd // dup arg workaround
+
+	// for each of the path components
+	for _, name := range names {
+
+		var next u.Key
+		var nlink *merkledag.Link
+		// for each of the links in nd, the current object
+		for _, link := range nd.Links {
+			if link.Name == name {
+				next = u.Key(link.Hash)
+				nlink = link
+				break
+			}
+		}
+
+		if next == "" {
+			h1, _ := nd.Multihash()
+			h2 := h1.B58String()
+			return nil, fmt.Errorf("no link named %q under %s", name, h2)
+		}
+
+		if nlink.Node == nil {
+			// fetch object for link and assign to nd
+			nd, err = s.DAG.Get(next)
+			if err != nil {
+				return nd, err
+			}
+			nlink.Node = nd
+		} else {
+			nd = nlink.Node
+		}
+	}
+	return
+}

--- a/server/http/ipfs.go
+++ b/server/http/ipfs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jbenet/go-ipfs/importer"
 	chunk "github.com/jbenet/go-ipfs/importer/chunk"
 	dag "github.com/jbenet/go-ipfs/merkledag"
+	path "github.com/jbenet/go-ipfs/path"
 	uio "github.com/jbenet/go-ipfs/unixfs/io"
 	u "github.com/jbenet/go-ipfs/util"
 )
@@ -23,8 +24,8 @@ type ipfsHandler struct {
 	node *core.IpfsNode
 }
 
-func (i *ipfsHandler) ResolvePath(path string) (*dag.Node, error) {
-	return i.node.Resolver.ResolvePath(path)
+func (i *ipfsHandler) ResolvePath(fpath string) (*dag.Node, error) {
+	return i.node.Resolver.ResolvePath(path.Path(fpath))
 }
 
 func (i *ipfsHandler) NewDagFromReader(r io.Reader) (*dag.Node, error) {

--- a/test/epictest/addcat_test.go
+++ b/test/epictest/addcat_test.go
@@ -15,6 +15,7 @@ import (
 	coreunix "github.com/jbenet/go-ipfs/core/coreunix"
 	mocknet "github.com/jbenet/go-ipfs/p2p/net/mock"
 	"github.com/jbenet/go-ipfs/p2p/peer"
+	path "github.com/jbenet/go-ipfs/path"
 	"github.com/jbenet/go-ipfs/thirdparty/unit"
 	errors "github.com/jbenet/go-ipfs/util/debugerror"
 	testutil "github.com/jbenet/go-ipfs/util/testutil"
@@ -130,7 +131,7 @@ func DirectAddCat(data []byte, conf testutil.LatencyConfig) error {
 		return err
 	}
 
-	readerCatted, err := coreunix.Cat(catter, keyAdded.String())
+	readerCatted, err := coreunix.Cat(catter, path.Path(keyAdded.String()))
 	if err != nil {
 		return err
 	}

--- a/test/epictest/three_legged_cat_test.go
+++ b/test/epictest/three_legged_cat_test.go
@@ -12,6 +12,7 @@ import (
 	coreunix "github.com/jbenet/go-ipfs/core/coreunix"
 	mocknet "github.com/jbenet/go-ipfs/p2p/net/mock"
 	"github.com/jbenet/go-ipfs/p2p/peer"
+	path "github.com/jbenet/go-ipfs/path"
 	"github.com/jbenet/go-ipfs/thirdparty/unit"
 	errors "github.com/jbenet/go-ipfs/util/debugerror"
 	testutil "github.com/jbenet/go-ipfs/util/testutil"
@@ -110,7 +111,7 @@ func RunThreeLeggedCat(data []byte, conf testutil.LatencyConfig) error {
 		return err
 	}
 
-	readerCatted, err := coreunix.Cat(catter, keyAdded.String())
+	readerCatted, err := coreunix.Cat(catter, path.Path(keyAdded.String()))
 	if err != nil {
 		return err
 	}

--- a/unixfs/tar/reader.go
+++ b/unixfs/tar/reader.go
@@ -7,7 +7,6 @@ import (
 	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
 	"io"
 	gopath "path"
-	"strings"
 	"time"
 
 	mdag "github.com/jbenet/go-ipfs/merkledag"
@@ -29,10 +28,7 @@ type Reader struct {
 	err        error
 }
 
-func NewReader(path string, dag mdag.DAGService, resolver *path.Resolver, compression int) (*Reader, error) {
-	if strings.HasPrefix(path, "/ipfs/") {
-		path = path[6:]
-	}
+func NewReader(path path.Path, dag mdag.DAGService, resolver *path.Resolver, compression int) (*Reader, error) {
 
 	reader := &Reader{
 		signalChan: make(chan struct{}),
@@ -58,7 +54,7 @@ func NewReader(path string, dag mdag.DAGService, resolver *path.Resolver, compre
 
 	// writeToBuf will write the data to the buffer, and will signal when there
 	// is new data to read
-	_, filename := gopath.Split(path)
+	_, filename := gopath.Split(path.String())
 	go reader.writeToBuf(dagnode, filename, 0)
 
 	return reader, nil

--- a/util/key.go
+++ b/util/key.go
@@ -120,6 +120,10 @@ func IsValidHash(s string) bool {
 	if out == nil || len(out) == 0 {
 		return false
 	}
+	_, err := mh.Cast(out)
+	if err != nil {
+		return false
+	}
 	return true
 }
 


### PR DESCRIPTION
This PR implements a path type for ipfs. The goal, is to avoid type safety problems between using strings and keys to specify an object to work with. My aim with this was utter simplicity, so the type is just a typedefed string, which allows it to be compared via `==`.

I considered making a constructor `path.FromString` that would clean up the input (call `gopath.Clean`, strip off leading `/ipfs/`, etc), But i didnt want people to be able to create a path type outside of the constructor, if it provides extra safety/assumptions