### PR TITLE
return connected peers as providers

### DIFF
--- a/exchange/bitswap/bitswap_test.go
+++ b/exchange/bitswap/bitswap_test.go
@@ -244,6 +244,7 @@ func TestSendToWantingPeer(t *testing.T) {
 func TestBasicBitswap(t *testing.T) {
 	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(kNetworkDelay))
 	sg := NewTestSessionGenerator(net)
+	defer sg.Close()
 	bg := blocksutil.NewBlockGenerator()
 
 	t.Log("Test a few nodes trying to get one file with a lot of blocks")

--- a/exchange/bitswap/bitswap_test.go
+++ b/exchange/bitswap/bitswap_test.go
@@ -36,23 +36,6 @@ func TestClose(t *testing.T) {
 	bitswap.Exchange.GetBlock(context.Background(), block.Key())
 }
 
-func TestGetBlockTimeout(t *testing.T) {
-
-	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(kNetworkDelay))
-	g := NewTestSessionGenerator(net)
-	defer g.Close()
-
-	self := g.Next()
-
-	ctx, _ := context.WithTimeout(context.Background(), time.Nanosecond)
-	block := blocks.NewBlock([]byte("block"))
-	_, err := self.Exchange.GetBlock(ctx, block.Key())
-
-	if err != context.DeadlineExceeded {
-		t.Fatal("Expected DeadlineExceeded error")
-	}
-}
-
 func TestProviderForKeyButNetworkCannotFind(t *testing.T) { // TODO revisit this
 
 	rs := mockrouting.NewServer()

--- a/exchange/bitswap/network/ipfs_impl.go
+++ b/exchange/bitswap/network/ipfs_impl.go
@@ -108,7 +108,7 @@ func (bsnet *impl) FindProvidersAsync(ctx context.Context, k util.Key, max int) 
 	// the short term.
 	connectedPeers := bsnet.host.Network().Peers()
 	out := make(chan peer.ID, len(connectedPeers)) // just enough buffer for these connectedPeers
-	for _, id := range bsnet.host.Network().Peers() {
+	for _, id := range connectedPeers {
 		out <- id
 	}
 

--- a/p2p/net/swarm/simul_test.go
+++ b/p2p/net/swarm/simul_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	peer "github.com/jbenet/go-ipfs/p2p/peer"
+	ci "github.com/jbenet/go-ipfs/util/testutil/ci"
 
 	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
 	ma "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
@@ -45,10 +46,14 @@ func TestSimultOpen(t *testing.T) {
 
 func TestSimultOpenMany(t *testing.T) {
 	// t.Skip("very very slow")
-	t.Parallel()
 
 	addrs := 20
-	SubtestSwarm(t, addrs, 10)
+	rounds := 10
+	if ci.IsRunning() {
+		addrs = 10
+		rounds = 5
+	}
+	SubtestSwarm(t, addrs, rounds)
 }
 
 func TestSimultOpenFewStress(t *testing.T) {

--- a/test/epictest/bitswap_wo_routing_test.go
+++ b/test/epictest/bitswap_wo_routing_test.go
@@ -1,0 +1,104 @@
+package epictest
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
+	"github.com/jbenet/go-ipfs/blocks"
+	"github.com/jbenet/go-ipfs/core"
+	mocknet "github.com/jbenet/go-ipfs/p2p/net/mock"
+	errors "github.com/jbenet/go-ipfs/util/debugerror"
+	testutil "github.com/jbenet/go-ipfs/util/testutil"
+)
+
+func TestBitswapWithoutRouting(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	const numPeers = 4
+
+	// create network
+	mn, err := mocknet.FullMeshLinked(ctx, numPeers)
+	if err != nil {
+		t.Fatal(errors.Wrap(err))
+	}
+
+	peers := mn.Peers()
+	if len(peers) < numPeers {
+		t.Fatal(errors.New("test initialization error"))
+	}
+
+	// set the routing latency to infinity.
+	conf := testutil.LatencyConfig{RoutingLatency: (525600 * time.Minute)}
+
+	var nodes []*core.IpfsNode
+	for _, p := range peers {
+		n, err := core.NewIPFSNode(ctx, core.ConfigOption(MocknetTestRepo(p, mn.Host(p), conf)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer n.Close()
+		nodes = append(nodes, n)
+	}
+
+	// connect them
+	for _, n1 := range nodes {
+		for _, n2 := range nodes {
+			if n1 == n2 {
+				continue
+			}
+
+			log.Debug("connecting to other hosts")
+			p2 := n2.PeerHost.Peerstore().PeerInfo(n2.PeerHost.ID())
+			if err := n1.PeerHost.Connect(ctx, p2); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// add blocks to each before
+	log.Debug("adding block.")
+	block0 := blocks.NewBlock([]byte("block0"))
+	block1 := blocks.NewBlock([]byte("block1"))
+
+	// put 1 before
+	if err := nodes[0].Blockstore.Put(block0); err != nil {
+		t.Fatal(err)
+	}
+
+	//  get it out.
+	for i, n := range nodes {
+		// skip first because block not in its exchange. will hang.
+		if i == 0 {
+			continue
+		}
+
+		log.Debugf("%d %s get block.", i, n.Identity)
+		b, err := n.Exchange.GetBlock(ctx, block0.Key())
+		if err != nil {
+			t.Error(err)
+		} else if !bytes.Equal(b.Data, block0.Data) {
+			t.Error("byte comparison fail")
+		} else {
+			log.Debug("got block: %s", b.Key())
+		}
+	}
+
+	// put 1 after
+	if err := nodes[1].Blockstore.Put(block1); err != nil {
+		t.Fatal(err)
+	}
+
+	//  get it out.
+	for _, n := range nodes {
+		b, err := n.Exchange.GetBlock(ctx, block1.Key())
+		if err != nil {
+			t.Error(err)
+		} else if !bytes.Equal(b.Data, block1.Data) {
+			t.Error("byte comparison fail")
+		} else {
+			log.Debug("got block: %s", b.Key())
+		}
+	}
+}


### PR DESCRIPTION
Also:
- epictest: added test for bitswap wo routing
- fixed three-legged-cat (i think)

![](http://gateway.ipfs.io/ipfs/QmfUFkQuqjfQzLNhMLwiibiAxnAaZEJAbYkey9orXJ4aQe/3lcat.jpg)