### PR TITLE
implement a faster dag structure for unixfs

### DIFF
--- a/importer/builddag_fast.go
+++ b/importer/builddag_fast.go
@@ -1,0 +1,102 @@
+package importer
+
+import (
+	"io"
+
+	"github.com/jbenet/go-ipfs/importer/chunk"
+	dag "github.com/jbenet/go-ipfs/merkledag"
+	"github.com/jbenet/go-ipfs/pin"
+	ft "github.com/jbenet/go-ipfs/unixfs"
+	u "github.com/jbenet/go-ipfs/util"
+)
+
+func BuildFastDagFromReader(r io.Reader, ds dag.DAGService, mp pin.ManualPinner, spl chunk.BlockSplitter) (*dag.Node, error) {
+	// Start the splitter
+	blkch := spl.Split(r)
+
+	// Create our builder helper
+	db := &dagBuilderHelper{
+		dserv:    ds,
+		mp:       mp,
+		in:       blkch,
+		maxlinks: DefaultLinksPerBlock,
+		indrSize: defaultIndirectBlockDataSize(),
+	}
+
+	root := newUnixfsNode()
+
+	for level := 1; !db.done(); level++ {
+		rotate(db, root)
+		err := db.fillStreamNodeRec(root, level)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	rootnode, err := root.getDagNode()
+	if err != nil {
+		return nil, err
+	}
+
+	rootkey, err := ds.Add(rootnode)
+	if err != nil {
+		return nil, err
+	}
+
+	if mp != nil {
+		mp.PinWithMode(rootkey, pin.Recursive)
+		err := mp.Flush()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return root.getDagNode()
+}
+
+// rotate performs a recursive tree rotation down the leftmost child
+// this attains a moderately balanced tree while retaining node odering
+// postconditions: The given node will have a single child, and a
+// correctly adjusted MultiBlock object
+func rotate(db *dagBuilderHelper, node *unixfsNode) error {
+	// base case
+	if node.numChildren() == 0 {
+		return nil
+	}
+
+	// Grab our links
+	links := node.node.Links
+
+	// Get our first child (have to reload for modification)
+	leftnode, err := db.dserv.Get(u.Key(links[0].Hash))
+	if err != nil {
+		return err
+	}
+
+	lfsnode, err := unixfsNodeFromDagNode(leftnode)
+	if err != nil {
+		return err
+	}
+
+	// rotate our first child tree
+	err = rotate(db, lfsnode)
+	if err != nil {
+		return err
+	}
+
+	// Add all our children to our left child
+	for i, l := range links[1:] {
+		lfsnode.node.Links = append(lfsnode.node.Links, l)
+		lfsnode.ufmt.AddBlockSize(node.ufmt.GetBlocksizes()[i])
+	}
+
+	// Reset our current node, and re-add our lone child
+	node.ufmt = new(ft.MultiBlock)
+	node.node.Links = nil
+	err = node.addChild(lfsnode, db)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/unixfs/format.go
+++ b/unixfs/format.go
@@ -104,6 +104,22 @@ type MultiBlock struct {
 	subtotal   uint64
 }
 
+func BytesToMultiblock(b []byte) (*MultiBlock, error) {
+	pbn := new(pb.Data)
+	err := proto.Unmarshal(b, pbn)
+	if err != nil {
+		return nil, err
+	}
+
+	mb := new(MultiBlock)
+	mb.Data = pbn.Data
+	mb.blocksizes = pbn.Blocksizes
+	for _, s := range mb.blocksizes {
+		mb.subtotal += s
+	}
+	return mb, nil
+}
+
 func (mb *MultiBlock) AddBlockSize(s uint64) {
 	mb.subtotal += s
 	mb.blocksizes = append(mb.blocksizes, s)
@@ -117,6 +133,10 @@ func (mb *MultiBlock) GetBytes() ([]byte, error) {
 	pbn.Blocksizes = mb.blocksizes
 	pbn.Data = mb.Data
 	return proto.Marshal(pbn)
+}
+
+func (mb *MultiBlock) GetBlocksizes() []uint64 {
+	return mb.GetBlocksizes()
 }
 
 func (mb *MultiBlock) FileSize() uint64 {


### PR DESCRIPTION
Note: This code isnt alpha priority, and while it works and ive tested it pretty well, isnt on our TODO list. So other code should take priority.
This PR adds an alternate method in importer to build a DAG with. This method ensures that every node has data in it, making streaming much faster since you'll have some data to display while you're fetching the next blocks. I accomplish a mostly balanced tree by performing a sort of 'rotate' every time the required depth has filled up. This rotate moves all but the first child node under the first child node to make room for more nodes to be added at the root level. Doing this rotate ensures that the in pre-order traversal of the tree remains the same throughout the trees creation.