### PR TITLE
p2p/net: network interface Listen func

### DIFF
--- a/p2p/net/interface.go
+++ b/p2p/net/interface.go
@@ -69,6 +69,9 @@ type Network interface {
 	// If there is no connection to p, attempts to create one.
 	NewStream(peer.ID) (Stream, error)
 
+	// Listen tells the network to start listening on given multiaddrs.
+	Listen(...ma.Multiaddr) error
+
 	// ListenAddresses returns a list of addresses at which this network listens.
 	ListenAddresses() []ma.Multiaddr
 

--- a/p2p/net/mock/mock_peernet.go
+++ b/p2p/net/mock/mock_peernet.go
@@ -305,6 +305,12 @@ func (pn *peernet) BandwidthTotals() (in uint64, out uint64) {
 	return 0, 0
 }
 
+// Listen tells the network to start listening on given multiaddrs.
+func (pn *peernet) Listen(addrs ...ma.Multiaddr) error {
+	pn.Peerstore().AddAddresses(pn.LocalPeer(), addrs)
+	return nil
+}
+
 // ListenAddresses returns a list of addresses at which this network listens.
 func (pn *peernet) ListenAddresses() []ma.Multiaddr {
 	return pn.Peerstore().Addresses(pn.LocalPeer())

--- a/p2p/net/swarm/swarm.go
+++ b/p2p/net/swarm/swarm.go
@@ -49,12 +49,9 @@ type Swarm struct {
 func NewSwarm(ctx context.Context, listenAddrs []ma.Multiaddr,
 	local peer.ID, peers peer.Peerstore) (*Swarm, error) {
 
-	if len(listenAddrs) > 0 {
-		filtered := addrutil.FilterUsableAddrs(listenAddrs)
-		if len(filtered) < 1 {
-			return nil, fmt.Errorf("swarm cannot use any addr in: %s", listenAddrs)
-		}
-		listenAddrs = filtered
+	listenAddrs, err := filterAddrs(listenAddrs)
+	if err != nil {
+		return nil, err
 	}
 
 	s := &Swarm{
@@ -75,6 +72,28 @@ func NewSwarm(ctx context.Context, listenAddrs []ma.Multiaddr,
 
 func (s *Swarm) teardown() error {
 	return s.swarm.Close()
+}
+
+// CtxGroup returns the Context Group of the swarm
+func filterAddrs(listenAddrs []ma.Multiaddr) ([]ma.Multiaddr, error) {
+	if len(listenAddrs) > 0 {
+		filtered := addrutil.FilterUsableAddrs(listenAddrs)
+		if len(filtered) < 1 {
+			return nil, fmt.Errorf("swarm cannot use any addr in: %s", listenAddrs)
+		}
+		listenAddrs = filtered
+	}
+	return listenAddrs, nil
+}
+
+// CtxGroup returns the Context Group of the swarm
+func (s *Swarm) Listen(addrs ...ma.Multiaddr) error {
+	addrs, err := filterAddrs(addrs)
+	if err != nil {
+		return err
+	}
+
+	return s.listen(addrs)
 }
 
 // CtxGroup returns the Context Group of the swarm

--- a/p2p/net/swarm/swarm_net.go
+++ b/p2p/net/swarm/swarm_net.go
@@ -102,6 +102,11 @@ func (n *Network) Close() error {
 	return n.Swarm().cg.Close()
 }
 
+// Listen tells the network to start listening on given multiaddrs.
+func (n *Network) Listen(addrs ...ma.Multiaddr) error {
+	return n.Swarm().Listen(addrs...)
+}
+
 // ListenAddresses returns a list of addresses at which this network listens.
 func (n *Network) ListenAddresses() []ma.Multiaddr {
 	return n.Swarm().ListenAddresses()


### PR DESCRIPTION
network interface now allows setting Listeners after the fact.
This is useful to create the network and start listening as
separate steps. And to keep the network up to date on new
addresses the node might have to listen to.