### PR TITLE
dont rewrite a block thats already in the datastore

### DIFF
--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -66,7 +66,15 @@ func New(bs blockstore.Blockstore, rem exchange.Interface) (*BlockService, error
 // TODO pass a context into this if the remote.HasBlock is going to remain here.
 func (s *BlockService) AddBlock(b *blocks.Block) (u.Key, error) {
 	k := b.Key()
-	err := s.Blockstore.Put(b)
+	has, err := s.Blockstore.Has(k)
+	if err != nil {
+		return "", err
+	}
+	if has {
+		return k, nil
+	}
+
+	err = s.Blockstore.Put(b)
 	if err != nil {
 		return k, err
 	}


### PR DESCRIPTION
I noticed @travisperson readding files to find out their hashes again, and it was taking forever. Theres no need to write the data to disk if its already there... This fixes that!