### PR TITLE
blockservice/worker: fix proc/limiter sync

### DIFF
--- a/blockservice/worker/worker.go
+++ b/blockservice/worker/worker.go
@@ -120,7 +120,8 @@ func (w *Worker) start(c Config) {
 	// reads from |workerChan| until process closes
 	w.process.Go(func(proc process.Process) {
 		ctx := childContext(proc) // shut down in-progress HasBlock when time to die
-		limiter := ratelimit.NewRateLimiter(proc, c.NumWorkers)
+		limiter := ratelimit.NewRateLimiter(process.Background(), c.NumWorkers)
+		defer limiter.Close()
 		for {
 			select {
 			case <-proc.Closing():


### PR DESCRIPTION
see: https://gist.github.com/jbenet/6b8b45bde9d9fce17d57

I want to make the goprocess API nicer so it doesnt lead
users into this problem. any ideas?