### PR TITLE
ipfs add -w

### DIFF
--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -67,6 +67,8 @@ func AddR(n *core.IpfsNode, root string) (key string, err error) {
 
 // AddWrapped adds data from a reader, and wraps it with a directory object
 // to preserve the filename.
+// Returns the path of the added file ("<dir hash>/filename"), the DAG node of
+// the directory, and and error if any.
 func AddWrapped(n *core.IpfsNode, r io.Reader, filename string) (string, *merkledag.Node, error) {
 	file := files.NewReaderFile(filename, ioutil.NopCloser(r), nil)
 	dir := files.NewSliceFile("", []files.File{file})

--- a/core/coreunix/add.go
+++ b/core/coreunix/add.go
@@ -3,6 +3,7 @@ package coreunix
 import (
 	"errors"
 	"io"
+	"io/ioutil"
 	"os"
 	gopath "path"
 
@@ -62,6 +63,22 @@ func AddR(n *core.IpfsNode, root string) (key string, err error) {
 		return "", err
 	}
 	return k.String(), nil
+}
+
+// AddWrapped adds data from a reader, and wraps it with a directory object
+// to preserve the filename.
+func AddWrapped(n *core.IpfsNode, r io.Reader, filename string) (string, *merkledag.Node, error) {
+	file := files.NewReaderFile(filename, ioutil.NopCloser(r), nil)
+	dir := files.NewSliceFile("", []files.File{file})
+	dagnode, err := addDir(n, dir)
+	if err != nil {
+		return "", nil, err
+	}
+	k, err := dagnode.Key()
+	if err != nil {
+		return "", nil, err
+	}
+	return gopath.Join(k.String(), filename), dagnode, nil
 }
 
 func add(n *core.IpfsNode, readers []io.Reader) ([]*merkledag.Node, error) {

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -171,7 +171,7 @@ test_expect_success "ipfs add -w succeeds" '
 
 test_expect_success "ipfs add -w output looks good" '
 	HASH="QmVJfrqd4ogGZME6LWkkikAGddYgh9dBs2U14DHZZUBk7W" &&
-	echo "added "$HASH/hello.txt" mountdir/hello.txt" >expected &&
+	echo "added $HASH/hello.txt mountdir/hello.txt" >expected &&
 	test_cmp expected actual
 '
 

--- a/test/sharness/t0040-add-and-cat.sh
+++ b/test/sharness/t0040-add-and-cat.sh
@@ -165,6 +165,16 @@ test_expect_success FUSE,EXPENSIVE "cat ipfs/bigfile looks good" '
 	test_cmp sha1_expected sha1_actual
 '
 
+test_expect_success "ipfs add -w succeeds" '
+	ipfs add -w mountdir/hello.txt >actual
+'
+
+test_expect_success "ipfs add -w output looks good" '
+	HASH="QmVJfrqd4ogGZME6LWkkikAGddYgh9dBs2U14DHZZUBk7W" &&
+	echo "added "$HASH/hello.txt" mountdir/hello.txt" >expected &&
+	test_cmp expected actual
+'
+
 test_kill_ipfs_daemon
 
 test_done


### PR DESCRIPTION
This PR adds a `-w` or `--wrap-with-directory` flag to `ipfs add`, so that files can have their name preserved. For example, `ipfs add -w file.txt` should output `added <hash>/file.txt file.txt`.