### PR TITLE
implement metadata node for unixfs and other

### DIFF
--- a/core/coreunix/metadata.go
+++ b/core/coreunix/metadata.go
@@ -1,13 +1,14 @@
 package coreunix
 
 import (
+	core "github.com/jbenet/go-ipfs/core"
 	dag "github.com/jbenet/go-ipfs/merkledag"
 	ft "github.com/jbenet/go-ipfs/unixfs"
 	u "github.com/jbenet/go-ipfs/util"
 )
 
-func AddMetadataTo(key u.Key, m *ft.Metadata, dserv dag.DAGService) (u.Key, error) {
-	nd, err := dserv.Get(key)
+func AddMetadataTo(key u.Key, m *ft.Metadata, n *core.IpfsNode) (u.Key, error) {
+	nd, err := n.DAG.Get(key)
 	if err != nil {
 		return "", err
 	}
@@ -24,11 +25,11 @@ func AddMetadataTo(key u.Key, m *ft.Metadata, dserv dag.DAGService) (u.Key, erro
 		return "", err
 	}
 
-	return dserv.Add(mdnode)
+	return n.DAG.Add(mdnode)
 }
 
-func Metadata(key u.Key, dserv dag.DAGService) (*ft.Metadata, error) {
-	nd, err := dserv.Get(key)
+func Metadata(key u.Key, n *core.IpfsNode) (*ft.Metadata, error) {
+	nd, err := n.DAG.Get(key)
 	if err != nil {
 		return nil, err
 	}

--- a/core/coreunix/metadata.go
+++ b/core/coreunix/metadata.go
@@ -1,0 +1,37 @@
+package coreunix
+
+import (
+	dag "github.com/jbenet/go-ipfs/merkledag"
+	ft "github.com/jbenet/go-ipfs/unixfs"
+	u "github.com/jbenet/go-ipfs/util"
+)
+
+func AddMetadataTo(key u.Key, m *ft.Metadata, dserv dag.DAGService) (u.Key, error) {
+	nd, err := dserv.Get(key)
+	if err != nil {
+		return "", err
+	}
+
+	mdnode := new(dag.Node)
+	mdata, err := ft.BytesForMetadata(m)
+	if err != nil {
+		return "", err
+	}
+
+	mdnode.Data = mdata
+	err = mdnode.AddNodeLinkClean("file", nd)
+	if err != nil {
+		return "", err
+	}
+
+	return dserv.Add(mdnode)
+}
+
+func Metadata(key u.Key, dserv dag.DAGService) (*ft.Metadata, error) {
+	nd, err := dserv.Get(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return ft.MetadataFromBytes(nd.Data)
+}

--- a/core/coreunix/metadata.go
+++ b/core/coreunix/metadata.go
@@ -7,8 +7,9 @@ import (
 	u "github.com/jbenet/go-ipfs/util"
 )
 
-func AddMetadataTo(key u.Key, m *ft.Metadata, n *core.IpfsNode) (u.Key, error) {
-	nd, err := n.DAG.Get(key)
+func AddMetadataTo(n *core.IpfsNode, key string, m *ft.Metadata) (string, error) {
+	ukey := u.B58KeyDecode(key)
+	nd, err := n.DAG.Get(ukey)
 	if err != nil {
 		return "", err
 	}
@@ -25,11 +26,17 @@ func AddMetadataTo(key u.Key, m *ft.Metadata, n *core.IpfsNode) (u.Key, error) {
 		return "", err
 	}
 
-	return n.DAG.Add(mdnode)
+	nk, err := n.DAG.Add(mdnode)
+	if err != nil {
+		return "", err
+	}
+
+	return nk.B58String(), nil
 }
 
-func Metadata(key u.Key, n *core.IpfsNode) (*ft.Metadata, error) {
-	nd, err := n.DAG.Get(key)
+func Metadata(n *core.IpfsNode, key string) (*ft.Metadata, error) {
+	ukey := u.B58KeyDecode(key)
+	nd, err := n.DAG.Get(ukey)
 	if err != nil {
 		return nil, err
 	}

--- a/core/coreunix/metadata_test.go
+++ b/core/coreunix/metadata_test.go
@@ -1,0 +1,82 @@
+package coreunix
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
+	ds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
+	dssync "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync"
+	bstore "github.com/jbenet/go-ipfs/blocks/blockstore"
+	bserv "github.com/jbenet/go-ipfs/blockservice"
+	offline "github.com/jbenet/go-ipfs/exchange/offline"
+	importer "github.com/jbenet/go-ipfs/importer"
+	chunk "github.com/jbenet/go-ipfs/importer/chunk"
+	merkledag "github.com/jbenet/go-ipfs/merkledag"
+	ft "github.com/jbenet/go-ipfs/unixfs"
+	uio "github.com/jbenet/go-ipfs/unixfs/io"
+	u "github.com/jbenet/go-ipfs/util"
+)
+
+func getDagservAndPinner(t *testing.T) merkledag.DAGService {
+	db := dssync.MutexWrap(ds.NewMapDatastore())
+	bs := bstore.NewBlockstore(db)
+	blockserv, err := bserv.New(bs, offline.Exchange(bs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return merkledag.NewDAGService(blockserv)
+}
+
+func TestMetadata(t *testing.T) {
+	// Make some random node
+	ds := getDagservAndPinner(t)
+	data := make([]byte, 1000)
+	u.NewTimeSeededRand().Read(data)
+	r := bytes.NewReader(data)
+	nd, err := importer.BuildDagFromReader(r, ds, nil, chunk.DefaultSplitter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	k, err := nd.Key()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := new(ft.Metadata)
+	m.MimeType = "THIS IS A TEST"
+
+	mdk, err := AddMetadataTo(k, m, ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec, err := Metadata(mdk, ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.MimeType != m.MimeType {
+		t.Fatalf("something went wrong in conversion: '%s' != '%s'", rec.MimeType, m.MimeType)
+	}
+
+	retnode, err := ds.Get(mdk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ndr, err := uio.NewDagReader(context.TODO(), retnode, ds)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := ioutil.ReadAll(ndr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(out, data) {
+		t.Fatal("read incorrect data")
+	}
+}

--- a/unixfs/pb/unixfs.pb.go
+++ b/unixfs/pb/unixfs.pb.go
@@ -10,10 +10,11 @@ It is generated from these files:
 
 It has these top-level messages:
 	Data
+	Metadata
 */
 package unixfs_pb
 
-import proto "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/gogoprotobuf/proto"
+import proto "code.google.com/p/gogoprotobuf/proto"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -26,17 +27,20 @@ const (
 	Data_Raw       Data_DataType = 0
 	Data_Directory Data_DataType = 1
 	Data_File      Data_DataType = 2
+	Data_Metadata  Data_DataType = 3
 )
 
 var Data_DataType_name = map[int32]string{
 	0: "Raw",
 	1: "Directory",
 	2: "File",
+	3: "Metadata",
 }
 var Data_DataType_value = map[string]int32{
 	"Raw":       0,
 	"Directory": 1,
 	"File":      2,
+	"Metadata":  3,
 }
 
 func (x Data_DataType) Enum() *Data_DataType {
@@ -94,6 +98,22 @@ func (m *Data) GetBlocksizes() []uint64 {
 		return m.Blocksizes
 	}
 	return nil
+}
+
+type Metadata struct {
+	MimeType         *string `protobuf:"bytes,1,req" json:"MimeType,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *Metadata) Reset()         { *m = Metadata{} }
+func (m *Metadata) String() string { return proto.CompactTextString(m) }
+func (*Metadata) ProtoMessage()    {}
+
+func (m *Metadata) GetMimeType() string {
+	if m != nil && m.MimeType != nil {
+		return *m.MimeType
+	}
+	return ""
 }
 
 func init() {

--- a/unixfs/pb/unixfs.proto
+++ b/unixfs/pb/unixfs.proto
@@ -5,10 +5,15 @@ message Data {
 		Raw = 0;
 		Directory = 1;
 		File = 2;
+		Metadata = 3;
 	}
 
 	required DataType Type = 1;
 	optional bytes Data = 2;
 	optional uint64 filesize = 3;
 	repeated uint64 blocksizes = 4;
+}
+
+message Metadata {
+	required string MimeType = 1;
 }

--- a/util/key.go
+++ b/util/key.go
@@ -23,6 +23,10 @@ func (k Key) Pretty() string {
 	return k.B58String()
 }
 
+func (k Key) ToMultihash() mh.Multihash {
+	return mh.Multihash(k)
+}
+
 // B58String returns Key in a b58 encoded string
 func (k Key) B58String() string {
 	return B58KeyEncode(k)


### PR DESCRIPTION
This allows you to add a Mime-Type to ipfs objects, example:
```
    m := &unixfs.Metadata{
        MimeType: "application/json",
    }
    keywithmeta, err := coreunix.AddMetadataToKey(mykey, m, dagservice)


    metadata := coreunix.Metadata(keywithmeta, dagservice)
```