### PR TITLE
logs: removed all log.Errors unhelpful to users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ go:
   - tip
 
 script:
-  - TRAVES=true make test
+  - make test
 
 env: TEST_NO_FUSE=1 TEST_VERBOSE=1

--- a/blocks/set/dbset.go
+++ b/blocks/set/dbset.go
@@ -22,7 +22,7 @@ func NewDBWrapperSet(d ds.Datastore, bset BlockSet) BlockSet {
 func (d *datastoreBlockSet) AddBlock(k util.Key) {
 	err := d.dstore.Put(k.DsKey(), []byte{})
 	if err != nil {
-		log.Errorf("blockset put error: %s", err)
+		log.Debugf("blockset put error: %s", err)
 	}
 
 	d.bset.AddBlock(k)

--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -122,7 +122,7 @@ func (s *BlockService) GetBlocks(ctx context.Context, ks []u.Key) <-chan *blocks
 
 		rblocks, err := s.Exchange.GetBlocks(ctx, misses)
 		if err != nil {
-			log.Errorf("Error with GetBlocks: %s", err)
+			log.Debugf("Error with GetBlocks: %s", err)
 			return
 		}
 

--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -483,20 +483,20 @@ func (i *cmdInvocation) setupInterruptHandler() {
 			n, err := ctx.GetNode()
 			if err != nil {
 				log.Error(err)
-				log.Critical("Received interrupt signal, terminating...")
+				fmt.Println("Received interrupt signal, terminating...")
 				os.Exit(-1)
 			}
 
 			switch count {
 			case 0:
-				log.Critical("Received interrupt signal, shutting down...")
+				fmt.Println("Received interrupt signal, shutting down...")
 				go func() {
 					n.Close()
 					log.Info("Gracefully shut down.")
 				}()
 
 			default:
-				log.Critical("Received another interrupt before graceful shutdown, terminating...")
+				fmt.Println("Received another interrupt before graceful shutdown, terminating...")
 				os.Exit(-1)
 			}
 		}

--- a/commands/http/handler.go
+++ b/commands/http/handler.go
@@ -129,7 +129,7 @@ func (i Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// w.WriteHeader(200)
 		err = copyChunks(applicationJson, w, out)
 		if err != nil {
-			log.Error(err)
+			log.Debug(err)
 		}
 		return
 	}

--- a/core/commands/ping.go
+++ b/core/commands/ping.go
@@ -150,7 +150,7 @@ func pingPeer(ctx context.Context, n *core.IpfsNode, pid peer.ID, numPings int) 
 			ctx, _ := context.WithTimeout(ctx, kPingTimeout)
 			took, err := n.Routing.Ping(ctx, pid)
 			if err != nil {
-				log.Errorf("Ping error: %s", err)
+				log.Debugf("Ping error: %s", err)
 				outChan <- &PingResult{Text: fmt.Sprintf("Ping error: %s", err)}
 				break
 			}

--- a/core/commands/refs.go
+++ b/core/commands/refs.go
@@ -110,7 +110,6 @@ Note: list all refs recursively with -r.
 
 			for _, o := range objs {
 				if _, err := rw.WriteRefs(o); err != nil {
-					log.Error(err)
 					eptr.SetError(err)
 					return
 				}
@@ -153,7 +152,6 @@ Displays the hashes of all local objects.
 			for k := range allKeys {
 				s := k.Pretty() + "\n"
 				if _, err := pipew.Write([]byte(s)); err != nil {
-					log.Error(err)
 					eptr.SetError(err)
 					return
 				}

--- a/core/commands/swarm.go
+++ b/core/commands/swarm.go
@@ -240,7 +240,7 @@ ipfs swarm disconnect /ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQA
 			conns := n.PeerHost.Network().ConnsToPeer(addr.ID())
 			for _, conn := range conns {
 				if !conn.RemoteMultiaddr().Equal(taddr) {
-					log.Error("it's not", conn.RemoteMultiaddr(), taddr)
+					log.Debug("it's not", conn.RemoteMultiaddr(), taddr)
 					continue
 				}
 

--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -155,7 +155,7 @@ func (i *gatewayHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		errmsg = errmsg + "bad request for " + r.URL.Path
 	}
 	w.Write([]byte(errmsg))
-	log.Error(errmsg)
+	log.Debug(errmsg)
 }
 
 func (i *gatewayHandler) getHandler(w http.ResponseWriter, r *http.Request) {
@@ -174,7 +174,6 @@ func (i *gatewayHandler) getHandler(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 		}
 
-		log.Error(err)
 		w.Write([]byte(err.Error()))
 		return
 	}
@@ -290,7 +289,7 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 	urlPath := r.URL.Path
 	pathext := urlPath[5:]
 	var err error
-	if urlPath == IpfsPathPrefix + "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn/" {
+	if urlPath == IpfsPathPrefix+"QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn/" {
 		i.putEmptyDirHandler(w, r)
 		return
 	}
@@ -326,7 +325,7 @@ func (i *gatewayHandler) putHandler(w http.ResponseWriter, r *http.Request) {
 		err = fmt.Errorf("Cannot override existing object")
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(err.Error()))
-		log.Error("%s", err)
+		log.Debug("%s", err)
 		return
 	}
 
@@ -450,7 +449,7 @@ func webError(w http.ResponseWriter, message string, err error, defaultCode int)
 
 func webErrorWithCode(w http.ResponseWriter, message string, err error, code int) {
 	w.WriteHeader(code)
-	log.Errorf("%s: %s", message, err)
+	log.Debugf("%s: %s", message, err)
 	w.Write([]byte(message + ": " + err.Error()))
 }
 
@@ -458,7 +457,7 @@ func webErrorWithCode(w http.ResponseWriter, message string, err error, code int
 func internalWebError(w http.ResponseWriter, err error) {
 	w.WriteHeader(http.StatusInternalServerError)
 	w.Write([]byte(err.Error()))
-	log.Error("%s", err)
+	log.Debug("%s", err)
 }
 
 // Directory listing template

--- a/core/corerepo/gc.go
+++ b/core/corerepo/gc.go
@@ -51,7 +51,7 @@ func GarbageCollectAsync(n *core.IpfsNode, ctx context.Context) (<-chan *KeyRemo
 				if !n.Pinning.IsPinned(k) {
 					err := n.Blockstore.DeleteBlock(k)
 					if err != nil {
-						log.Errorf("Error removing key from blockstore: %s", err)
+						log.Debugf("Error removing key from blockstore: %s", err)
 						continue
 					}
 					select {

--- a/diagnostics/diag.go
+++ b/diagnostics/diag.go
@@ -187,7 +187,7 @@ func (d *Diagnostics) getDiagnosticFromPeers(ctx context.Context, peers map[peer
 			defer wg.Done()
 			out, err := d.getDiagnosticFromPeer(ctx, p, pmes)
 			if err != nil {
-				log.Errorf("Error getting diagnostic from %s: %s", p, err)
+				log.Debugf("Error getting diagnostic from %s: %s", p, err)
 				return
 			}
 			for d := range out {
@@ -234,17 +234,17 @@ func (d *Diagnostics) getDiagnosticFromPeer(ctx context.Context, p peer.ID, pmes
 		for {
 			rpmes := new(pb.Message)
 			if err := r.ReadMsg(rpmes); err != nil {
-				log.Errorf("Error reading diagnostic from stream: %s", err)
+				log.Debugf("Error reading diagnostic from stream: %s", err)
 				return
 			}
 			if rpmes == nil {
-				log.Error("Got no response back from diag request.")
+				log.Debug("Got no response back from diag request.")
 				return
 			}
 
 			di, err := decodeDiagJson(rpmes.GetData())
 			if err != nil {
-				log.Error(err)
+				log.Debug(err)
 				return
 			}
 
@@ -276,7 +276,7 @@ func (d *Diagnostics) HandleMessage(ctx context.Context, s inet.Stream) error {
 	// deserialize msg
 	pmes := new(pb.Message)
 	if err := r.ReadMsg(pmes); err != nil {
-		log.Errorf("Failed to decode protobuf message: %v", err)
+		log.Debugf("Failed to decode protobuf message: %v", err)
 		return nil
 	}
 
@@ -292,7 +292,7 @@ func (d *Diagnostics) HandleMessage(ctx context.Context, s inet.Stream) error {
 	resp := newMessage(pmes.GetDiagID())
 	resp.Data = d.getDiagInfo().Marshal()
 	if err := w.WriteMsg(resp); err != nil {
-		log.Errorf("Failed to write protobuf message over stream: %s", err)
+		log.Debugf("Failed to write protobuf message over stream: %s", err)
 		return err
 	}
 
@@ -305,14 +305,14 @@ func (d *Diagnostics) HandleMessage(ctx context.Context, s inet.Stream) error {
 
 	dpeers, err := d.getDiagnosticFromPeers(ctx, d.getPeers(), pmes)
 	if err != nil {
-		log.Errorf("diagnostic from peers err: %s", err)
+		log.Debugf("diagnostic from peers err: %s", err)
 		return err
 	}
 	for b := range dpeers {
 		resp := newMessage(pmes.GetDiagID())
 		resp.Data = b.Marshal()
 		if err := w.WriteMsg(resp); err != nil {
-			log.Errorf("Failed to write protobuf message over stream: %s", err)
+			log.Debugf("Failed to write protobuf message over stream: %s", err)
 			return err
 		}
 	}

--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -211,7 +211,7 @@ func (bs *bitswap) sendWantlistMsgToPeers(ctx context.Context, m bsmsg.BitSwapMe
 		go func(p peer.ID) {
 			defer wg.Done()
 			if err := bs.send(ctx, p, m); err != nil {
-				log.Error(err) // TODO remove if too verbose
+				log.Debug(err) // TODO remove if too verbose
 			}
 		}(peerToQuery)
 	}
@@ -258,7 +258,7 @@ func (bs *bitswap) sendWantlistToProviders(ctx context.Context, entries []wantli
 
 	err := bs.sendWantlistToPeers(ctx, sendToPeers)
 	if err != nil {
-		log.Errorf("sendWantlistToPeers error: %s", err)
+		log.Debugf("sendWantlistToPeers error: %s", err)
 	}
 }
 
@@ -268,12 +268,12 @@ func (bs *bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg
 	defer log.EventBegin(ctx, "receiveMessage", p, incoming).Done()
 
 	if p == "" {
-		log.Error("Received message from nil peer!")
+		log.Debug("Received message from nil peer!")
 		// TODO propagate the error upward
 		return "", nil
 	}
 	if incoming == nil {
-		log.Error("Got nil bitswap message!")
+		log.Debug("Got nil bitswap message!")
 		// TODO propagate the error upward
 		return "", nil
 	}
@@ -287,7 +287,7 @@ func (bs *bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg
 	for _, block := range incoming.Blocks() {
 		hasBlockCtx, _ := context.WithTimeout(ctx, hasBlockTimeout)
 		if err := bs.HasBlock(hasBlockCtx, block); err != nil {
-			log.Error(err)
+			log.Debug(err)
 		}
 	}
 	var keys []u.Key
@@ -308,7 +308,7 @@ func (bs *bitswap) PeerConnected(p peer.ID) {
 	close(peers)
 	err := bs.sendWantlistToPeers(context.TODO(), peers)
 	if err != nil {
-		log.Errorf("error sending wantlist: %s", err)
+		log.Debugf("error sending wantlist: %s", err)
 	}
 }
 
@@ -329,13 +329,13 @@ func (bs *bitswap) cancelBlocks(ctx context.Context, bkeys []u.Key) {
 	for _, p := range bs.engine.Peers() {
 		err := bs.send(ctx, p, message)
 		if err != nil {
-			log.Errorf("Error sending message: %s", err)
+			log.Debugf("Error sending message: %s", err)
 		}
 	}
 }
 
 func (bs *bitswap) ReceiveError(err error) {
-	log.Errorf("Bitswap ReceiveError: %s", err)
+	log.Debugf("Bitswap ReceiveError: %s", err)
 	// TODO log the network error
 	// TODO bubble the network error up to the parent context/error logger
 }
@@ -413,7 +413,7 @@ func (bs *bitswap) clientWorker(parent context.Context) {
 			providers := bs.network.FindProvidersAsync(child, keys[0], maxProvidersPerRequest)
 			err := bs.sendWantlistToPeers(ctx, providers)
 			if err != nil {
-				log.Errorf("error sending wantlist: %s", err)
+				log.Debugf("error sending wantlist: %s", err)
 			}
 		case <-parent.Done():
 			return

--- a/exchange/bitswap/network/ipfs_impl.go
+++ b/exchange/bitswap/network/ipfs_impl.go
@@ -62,7 +62,7 @@ func (bsnet *impl) SendMessage(
 	defer s.Close()
 
 	if err := outgoing.ToNet(s); err != nil {
-		log.Errorf("error: %s", err)
+		log.Debugf("error: %s", err)
 		return err
 	}
 
@@ -81,13 +81,13 @@ func (bsnet *impl) SendRequest(
 	defer s.Close()
 
 	if err := outgoing.ToNet(s); err != nil {
-		log.Errorf("error: %s", err)
+		log.Debugf("error: %s", err)
 		return nil, err
 	}
 
 	incoming, err := bsmsg.FromNet(s)
 	if err != nil {
-		log.Errorf("error: %s", err)
+		log.Debugf("error: %s", err)
 		return incoming, err
 	}
 
@@ -150,7 +150,7 @@ func (bsnet *impl) handleNewStream(s inet.Stream) {
 	received, err := bsmsg.FromNet(s)
 	if err != nil {
 		go bsnet.receiver.ReceiveError(err)
-		log.Errorf("bitswap net handleNewStream from %s error: %s", s.Conn().RemotePeer(), err)
+		log.Debugf("bitswap net handleNewStream from %s error: %s", s.Conn().RemotePeer(), err)
 		return
 	}
 

--- a/exchange/reprovide/reprovide.go
+++ b/exchange/reprovide/reprovide.go
@@ -41,7 +41,7 @@ func (rp *Reprovider) ProvideEvery(ctx context.Context, tick time.Duration) {
 		case <-after:
 			err := rp.Reprovide(ctx)
 			if err != nil {
-				log.Error(err)
+				log.Debug(err)
 			}
 			after = time.After(tick)
 		}
@@ -57,7 +57,7 @@ func (rp *Reprovider) Reprovide(ctx context.Context) error {
 		op := func() error {
 			err := rp.rsys.Provide(ctx, k)
 			if err != nil {
-				log.Warningf("Failed to provide key: %s", err)
+				log.Debugf("Failed to provide key: %s", err)
 			}
 			return err
 		}
@@ -66,7 +66,7 @@ func (rp *Reprovider) Reprovide(ctx context.Context) error {
 		// eventually work contexts into it. low priority.
 		err := backoff.Retry(op, backoff.NewExponentialBackOff())
 		if err != nil {
-			log.Errorf("Providing failed after number of retries: %s", err)
+			log.Debugf("Providing failed after number of retries: %s", err)
 			return err
 		}
 	}

--- a/fuse/mount/mount.go
+++ b/fuse/mount/mount.go
@@ -107,7 +107,7 @@ func (m *mount) unmount() error {
 	if err == nil {
 		return nil
 	}
-	log.Error("fuse unmount err: %s", err)
+	log.Debug("fuse unmount err: %s", err)
 
 	// try closing the fuseConn
 	err = m.fuseConn.Close()
@@ -115,7 +115,7 @@ func (m *mount) unmount() error {
 		return nil
 	}
 	if err != nil {
-		log.Error("fuse conn error: %s", err)
+		log.Debug("fuse conn error: %s", err)
 	}
 
 	// try mount.ForceUnmountManyTimes

--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -110,7 +110,7 @@ func (s *Node) Attr() fuse.Attr {
 		}
 
 	default:
-		log.Error("Invalid data type.")
+		log.Debug("Invalid data type.")
 		return fuse.Attr{}
 	}
 }

--- a/importer/chunk/splitting.go
+++ b/importer/chunk/splitting.go
@@ -38,7 +38,7 @@ func (ss *SizeSplitter) Split(r io.Reader) chan []byte {
 				return
 			}
 			if err != nil {
-				log.Errorf("Block split error: %s", err)
+				log.Debugf("Block split error: %s", err)
 				return
 			}
 		}

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -136,7 +136,7 @@ func FetchGraph(ctx context.Context, root *Node, serv DAGService) chan struct{} 
 
 			nd, err := lnk.GetNode(serv)
 			if err != nil {
-				log.Error(err)
+				log.Debug(err)
 				return
 			}
 
@@ -199,7 +199,7 @@ func (ds *dagService) GetNodes(ctx context.Context, keys []u.Key) []NodeGetter {
 				nd, err := Decoded(blk.Data)
 				if err != nil {
 					// NB: can happen with improperly formatted input data
-					log.Error("Got back bad block!")
+					log.Debug("Got back bad block!")
 					return
 				}
 				is := FindLinks(keys, blk.Key(), 0)

--- a/namesys/publisher.go
+++ b/namesys/publisher.go
@@ -43,19 +43,16 @@ func (p *ipnsPublisher) Publish(ctx context.Context, k ci.PrivKey, value u.Key) 
 	// validate `value` is a ref (multihash)
 	_, err := mh.FromB58String(value.Pretty())
 	if err != nil {
-		log.Errorf("hash cast failed: %s", value)
 		return fmt.Errorf("publish value must be str multihash. %v", err)
 	}
 
 	data, err := createRoutingEntryData(k, value)
 	if err != nil {
-		log.Error("entry creation failed.")
 		return err
 	}
 	pubkey := k.GetPublic()
 	pkbytes, err := pubkey.Bytes()
 	if err != nil {
-		log.Error("pubkey getbytes failed.")
 		return err
 	}
 
@@ -120,7 +117,7 @@ func ValidateIpnsRecord(k u.Key, val []byte) error {
 	case pb.IpnsEntry_EOL:
 		t, err := u.ParseRFC3339(string(entry.GetValidity()))
 		if err != nil {
-			log.Error("Failed parsing time for ipns record EOL")
+			log.Debug("Failed parsing time for ipns record EOL")
 			return err
 		}
 		if time.Now().After(t) {

--- a/p2p/net/swarm/swarm_listen.go
+++ b/p2p/net/swarm/swarm_listen.go
@@ -33,7 +33,7 @@ func (s *Swarm) listen(addrs []ma.Multiaddr) error {
 				retErr.Errors = make([]error, len(addrs))
 			}
 			retErr.Errors[i] = err
-			log.Errorf("Failed to listen on: %s - %s", addr, err)
+			log.Debugf("Failed to listen on: %s - %s", addr, err)
 		}
 	}
 
@@ -122,7 +122,7 @@ func (s *Swarm) connHandler(c *ps.Conn) *Conn {
 
 	sc, err := s.newConnSetup(ctx, c)
 	if err != nil {
-		log.Error(err)
+		log.Debug(err)
 		log.Event(ctx, "newConnHandlerDisconnect", lgbl.NetConn(c.NetConn()), lgbl.Error(err))
 		c.Close() // boom. close it.
 		return nil

--- a/p2p/net/swarm/swarm_test.go
+++ b/p2p/net/swarm/swarm_test.go
@@ -22,25 +22,25 @@ func EchoStreamHandler(stream inet.Stream) {
 
 		// pull out the ipfs conn
 		c := stream.Conn()
-		log.Debugf("%s ponging to %s", c.LocalPeer(), c.RemotePeer())
+		log.Infof("%s ponging to %s", c.LocalPeer(), c.RemotePeer())
 
 		buf := make([]byte, 4)
 
 		for {
 			if _, err := stream.Read(buf); err != nil {
 				if err != io.EOF {
-					log.Error("ping receive error:", err)
+					log.Info("ping receive error:", err)
 				}
 				return
 			}
 
 			if !bytes.Equal(buf, []byte("ping")) {
-				log.Errorf("ping receive error: ping != %s %v", buf, buf)
+				log.Infof("ping receive error: ping != %s %v", buf, buf)
 				return
 			}
 
 			if _, err := stream.Write([]byte("pong")); err != nil {
-				log.Error("pond send error:", err)
+				log.Info("pond send error:", err)
 				return
 			}
 		}

--- a/p2p/protocol/mux.go
+++ b/p2p/protocol/mux.go
@@ -24,9 +24,8 @@ type streamHandlerMap map[ID]inet.StreamHandler
 // It contains the handlers for each protocol accepted.
 // It dispatches handlers for streams opened by remote peers.
 type Mux struct {
-
-	lock     sync.RWMutex
-	handlers streamHandlerMap
+	lock           sync.RWMutex
+	handlers       streamHandlerMap
 	defaultHandler inet.StreamHandler
 }
 
@@ -50,13 +49,11 @@ func (m *Mux) Protocols() []ID {
 // readHeader reads the stream and returns the next Handler function
 // according to the muxer encoding.
 func (m *Mux) readHeader(s io.Reader) (ID, inet.StreamHandler, error) {
-	// log.Error("ReadProtocolHeader")
 	p, err := ReadHeader(s)
 	if err != nil {
 		return "", nil, err
 	}
 
-	// log.Debug("readHeader got:", p)
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 	h, found := m.handlers[p]

--- a/p2p/test/backpressure/backpressure_test.go
+++ b/p2p/test/backpressure/backpressure_test.go
@@ -66,9 +66,9 @@ a problem.
 			// our request handler. can do stuff here. we
 			// simulate something taking time by waiting
 			// on requestHandled
-			log.Error("request worker handling...")
+			log.Debug("request worker handling...")
 			<-requestHandled
-			log.Error("request worker done!")
+			log.Debug("request worker done!")
 			receiverRatelimit <- struct{}{} // release
 		}()
 	}

--- a/routing/dht/dht_test.go
+++ b/routing/dht/dht_test.go
@@ -262,7 +262,7 @@ func waitForWellFormedTables(t *testing.T, dhts []*IpfsDHT, minPeers, avgPeers i
 	for {
 		select {
 		case <-timeoutA:
-			log.Errorf("did not reach well-formed routing tables by %s", timeout)
+			log.Debugf("did not reach well-formed routing tables by %s", timeout)
 			return false // failed
 		case <-time.After(5 * time.Millisecond):
 			if checkTables() {
@@ -322,7 +322,7 @@ func TestBootstrap(t *testing.T) {
 		}
 	}()
 
-	waitForWellFormedTables(t, dhts, 7, 10, 5*time.Second)
+	waitForWellFormedTables(t, dhts, 7, 10, 20*time.Second)
 	close(stop)
 
 	if u.Debug {
@@ -407,7 +407,7 @@ func TestPeriodicBootstrap(t *testing.T) {
 
 	// this is async, and we dont know when it's finished with one cycle, so keep checking
 	// until the routing tables look better, or some long timeout for the failure case.
-	waitForWellFormedTables(t, dhts, 7, 10, 5*time.Second)
+	waitForWellFormedTables(t, dhts, 7, 10, 20*time.Second)
 
 	if u.Debug {
 		printRoutingTables(dhts)

--- a/routing/grandcentral/client.go
+++ b/routing/grandcentral/client.go
@@ -44,13 +44,13 @@ func (c *Client) FindProvidersAsync(ctx context.Context, k u.Key, max int) <-cha
 		request := pb.NewMessage(pb.Message_GET_PROVIDERS, string(k), 0)
 		response, err := c.proxy.SendRequest(ctx, request)
 		if err != nil {
-			log.Error(errors.Wrap(err))
+			log.Debug(errors.Wrap(err))
 			return
 		}
 		for _, p := range pb.PBPeersToPeerInfos(response.GetProviderPeers()) {
 			select {
 			case <-ctx.Done():
-				log.Error(errors.Wrap(ctx.Err()))
+				log.Debug(errors.Wrap(ctx.Err()))
 				return
 			case ch <- p:
 			}

--- a/routing/grandcentral/proxy/loopback.go
+++ b/routing/grandcentral/proxy/loopback.go
@@ -2,9 +2,9 @@ package proxy
 
 import (
 	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
+	ggio "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/gogoprotobuf/io"
 	inet "github.com/jbenet/go-ipfs/p2p/net"
 	peer "github.com/jbenet/go-ipfs/p2p/peer"
-	ggio "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/gogoprotobuf/io"
 	dhtpb "github.com/jbenet/go-ipfs/routing/dht/pb"
 	errors "github.com/jbenet/go-ipfs/util/debugerror"
 )
@@ -39,7 +39,7 @@ func (lb *Loopback) handleNewStream(s inet.Stream) {
 	pbr := ggio.NewDelimitedReader(s, inet.MessageSizeMax)
 	var incoming dhtpb.Message
 	if err := pbr.ReadMsg(&incoming); err != nil {
-		log.Error(errors.Wrap(err))
+		log.Debug(errors.Wrap(err))
 		return
 	}
 	ctx := context.TODO()

--- a/routing/grandcentral/server.go
+++ b/routing/grandcentral/server.go
@@ -53,16 +53,16 @@ func (s *Server) handleMessage(
 		dskey := util.Key(req.GetKey()).DsKey()
 		val, err := s.datastore.Get(dskey)
 		if err != nil {
-			log.Error(errors.Wrap(err))
+			log.Debug(errors.Wrap(err))
 			return "", nil
 		}
 		rawRecord, ok := val.([]byte)
 		if !ok {
-			log.Errorf("datastore had non byte-slice value for %v", dskey)
+			log.Debugf("datastore had non byte-slice value for %v", dskey)
 			return "", nil
 		}
 		if err := proto.Unmarshal(rawRecord, response.Record); err != nil {
-			log.Error("failed to unmarshal dht record from datastore")
+			log.Debug("failed to unmarshal dht record from datastore")
 			return "", nil
 		}
 		// TODO before merging: if we know any providers for the requested value, return those.
@@ -72,12 +72,12 @@ func (s *Server) handleMessage(
 		// TODO before merging: verifyRecord(req.GetRecord())
 		data, err := proto.Marshal(req.GetRecord())
 		if err != nil {
-			log.Error(err)
+			log.Debug(err)
 			return "", nil
 		}
 		dskey := util.Key(req.GetKey()).DsKey()
 		if err := s.datastore.Put(dskey, data); err != nil {
-			log.Error(err)
+			log.Debug(err)
 			return "", nil
 		}
 		return p, req // TODO before merging: verify that we should return record
@@ -91,7 +91,7 @@ func (s *Server) handleMessage(
 		for _, provider := range req.GetProviderPeers() {
 			providerID := peer.ID(provider.GetId())
 			if providerID != p {
-				log.Errorf("provider message came from third-party %s", p)
+				log.Debugf("provider message came from third-party %s", p)
 				continue
 			}
 			for _, maddr := range provider.Addresses() {
@@ -107,7 +107,7 @@ func (s *Server) handleMessage(
 			}
 		}
 		if err := s.datastore.Put(pkey, providers); err != nil {
-			log.Error(err)
+			log.Debug(err)
 			return "", nil
 		}
 		return "", nil

--- a/tour/tour.go
+++ b/tour/tour.go
@@ -72,8 +72,8 @@ func compareDottedInts(i, o string) bool {
 		ivis, err1 := strconv.Atoi(vis)
 		ivos, err2 := strconv.Atoi(vos)
 		if err1 != nil || err2 != nil {
-			log.Error(err1)
-			log.Error(err2)
+			log.Debug(err1)
+			log.Debug(err2)
 			panic("tour ID LessThan: not an int")
 		}
 

--- a/updates/updates.go
+++ b/updates/updates.go
@@ -90,7 +90,7 @@ func init() {
 	var err error
 	currentVersion, err = parseVersion()
 	if err != nil {
-		log.Errorf("invalid version number in code (must be semver): %q", Version)
+		log.Criticalf("invalid version number in code (must be semver): %q", Version)
 		os.Exit(1)
 	}
 	log.Infof("go-ipfs Version: %s", currentVersion)


### PR DESCRIPTION
Let's save log.Error for things the user can take action on.
Moved all our diagnostics to log.Debug. We can ideally reduce them
even further.