### PR TITLE
when setting config keys, validate against struct before writing to disk

### DIFF
--- a/repo/config/init.go
+++ b/repo/config/init.go
@@ -42,7 +42,8 @@ func Init(out io.Writer, nBitsForKeypair int) (*Config, error) {
 		Datastore: *ds,
 		Identity:  identity,
 		Log: Log{
-			MaxSizeMB: 500,
+			MaxSizeMB:  250,
+			MaxBackups: 1,
 		},
 
 		// setup the node mount points.

--- a/repo/config/log.go
+++ b/repo/config/log.go
@@ -2,7 +2,7 @@ package config
 
 
 type Log struct {
-	MaxSizeMB  uint64
-	MaxBackups uint64
-	MaxAgeDays uint64
+	MaxSizeMB  int
+	MaxBackups int
+	MaxAgeDays int
 }

--- a/repo/fsrepo/component/config.go
+++ b/repo/fsrepo/component/config.go
@@ -93,13 +93,11 @@ func (c *ConfigComponent) SetConfigKey(key string, value interface{}) error {
 	if err := common.MapSetKV(mapconf, key, value); err != nil {
 		return err
 	}
-	if err := serialize.WriteConfigFile(filename, mapconf); err != nil {
-		return err
-	}
-	// in order to get the updated values, read updated config from the
-	// file-system.
 	conf, err := config.FromMap(mapconf)
 	if err != nil {
+		return err
+	}
+	if err := serialize.WriteConfigFile(filename, mapconf); err != nil {
 		return err
 	}
 	return c.setConfigUnsynced(conf) // TODO roll this into this method

--- a/repo/fsrepo/component/config.go
+++ b/repo/fsrepo/component/config.go
@@ -1,6 +1,8 @@
 package component
 
 import (
+	"strconv"
+
 	common "github.com/jbenet/go-ipfs/repo/common"
 	config "github.com/jbenet/go-ipfs/repo/config"
 	serialize "github.com/jbenet/go-ipfs/repo/fsrepo/serialize"
@@ -85,6 +87,12 @@ func (c *ConfigComponent) SetConfigKey(key string, value interface{}) error {
 	filename, err := config.Filename(c.path)
 	if err != nil {
 		return err
+	}
+	switch v := value.(type) {
+	case string:
+		if i, err := strconv.Atoi(v); err == nil {
+			value = i
+		}
 	}
 	var mapconf map[string]interface{}
 	if err := serialize.ReadConfigFile(filename, &mapconf); err != nil {

--- a/thirdparty/eventlog/option.go
+++ b/thirdparty/eventlog/option.go
@@ -38,9 +38,9 @@ var TextFormatter = func() {
 
 type LogRotatorConfig struct {
 	Filename   string
-	MaxSizeMB  uint64
-	MaxBackups uint64
-	MaxAgeDays uint64
+	MaxSizeMB  int
+	MaxBackups int
+	MaxAgeDays int
 }
 
 func Output(w io.Writer) Option {


### PR DESCRIPTION
RFCR @jbenet @whyrusleeping 

This addresses one part of #740. Now, the config is validated before being written to disk. Mismatched types will be rejected instead of being written to disk and breaking the config.