### PR TITLE
refactor core package and add 'net generator' interface

### DIFF
--- a/cmd/ipfs/main.go
+++ b/cmd/ipfs/main.go
@@ -191,7 +191,13 @@ func (i *cmdInvocation) constructNodeFunc(ctx context.Context) func() (*core.Ipf
 
 		// ok everything is good. set it on the invocation (for ownership)
 		// and return it.
-		n, err := core.NewIPFSNode(ctx, core.Standard(r, cmdctx.Online))
+		var cfgOpt core.ConfigOption
+		if cmdctx.Online {
+			cfgOpt = core.Online(r)
+		} else {
+			cfgOpt = core.Offline(r)
+		}
+		n, err := core.NewIPFSNode(ctx, cfgOpt)
 		if err != nil {
 			return nil, err
 		}

--- a/core/core.go
+++ b/core/core.go
@@ -7,7 +7,6 @@ import (
 
 	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
 	b58 "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-base58"
-	ctxgroup "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-ctxgroup"
 	datastore "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	ma "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
 
@@ -26,20 +25,14 @@ import (
 	dht "github.com/jbenet/go-ipfs/routing/dht"
 	offroute "github.com/jbenet/go-ipfs/routing/offline"
 
-	bstore "github.com/jbenet/go-ipfs/blocks/blockstore"
-	bserv "github.com/jbenet/go-ipfs/blockservice"
-	exchange "github.com/jbenet/go-ipfs/exchange"
 	bitswap "github.com/jbenet/go-ipfs/exchange/bitswap"
 	bsnet "github.com/jbenet/go-ipfs/exchange/bitswap/network"
-	offline "github.com/jbenet/go-ipfs/exchange/offline"
 	rp "github.com/jbenet/go-ipfs/exchange/reprovide"
 
 	mount "github.com/jbenet/go-ipfs/fuse/mount"
 	merkledag "github.com/jbenet/go-ipfs/merkledag"
 	namesys "github.com/jbenet/go-ipfs/namesys"
 	path "github.com/jbenet/go-ipfs/path"
-	pin "github.com/jbenet/go-ipfs/pin"
-	repo "github.com/jbenet/go-ipfs/repo"
 	config "github.com/jbenet/go-ipfs/repo/config"
 )
 
@@ -58,40 +51,6 @@ const (
 	onlineMode
 )
 
-// IpfsNode is IPFS Core module. It represents an IPFS instance.
-type IpfsNode struct {
-
-	// Self
-	Identity peer.ID // the local node's identity
-
-	Repo repo.Repo
-
-	// Local node
-	Pinning    pin.Pinner // the pinning manager
-	Mounts     Mounts     // current mount state, if any.
-	PrivateKey ic.PrivKey // the local node's private Key
-
-	// Services
-	Peerstore  peer.Peerstore       // storage for other Peer instances
-	Blockstore bstore.Blockstore    // the block store (lower level)
-	Blocks     *bserv.BlockService  // the block service, get/add blocks.
-	DAG        merkledag.DAGService // the merkle dag service, get/add objects.
-	Resolver   *path.Resolver       // the path resolution system
-
-	// Online
-	PeerHost     p2phost.Host        // the network host (server+client)
-	Bootstrapper io.Closer           // the periodic bootstrapper
-	Routing      routing.IpfsRouting // the routing system. recommend ipfs-dht
-	Exchange     exchange.Interface  // the block exchange + strategy (bitswap)
-	Namesys      namesys.NameSystem  // the name system, resolves paths to hashes
-	Diagnostics  *diag.Diagnostics   // the diagnostics service
-	Reprovider   *rp.Reprovider      // the value reprovider system
-
-	ctxgroup.ContextGroup
-
-	mode mode
-}
-
 // Mounts defines what the node's mount state is. This should
 // perhaps be moved to the daemon or mount. It's here because
 // it needs to be accessible across daemon requests.
@@ -100,122 +59,7 @@ type Mounts struct {
 	Ipns mount.Mount
 }
 
-type ConfigOption func(ctx context.Context) (*IpfsNode, error)
-
-func NewIPFSNode(parent context.Context, option ConfigOption) (*IpfsNode, error) {
-	ctxg := ctxgroup.WithContext(parent)
-	ctx := ctxg.Context()
-	success := false // flip to true after all sub-system inits succeed
-	defer func() {
-		if !success {
-			ctxg.Close()
-		}
-	}()
-
-	node, err := option(ctx)
-	if err != nil {
-		return nil, err
-	}
-	node.ContextGroup = ctxg
-	ctxg.SetTeardown(node.teardown)
-
-	// Need to make sure it's perfectly clear 1) which variables are expected
-	// to be initialized at this point, and 2) which variables will be
-	// initialized after this point.
-
-	node.Blocks, err = bserv.New(node.Blockstore, node.Exchange)
-	if err != nil {
-		return nil, debugerror.Wrap(err)
-	}
-	if node.Peerstore == nil {
-		node.Peerstore = peer.NewPeerstore()
-	}
-	node.DAG = merkledag.NewDAGService(node.Blocks)
-	node.Pinning, err = pin.LoadPinner(node.Repo.Datastore(), node.DAG)
-	if err != nil {
-		node.Pinning = pin.NewPinner(node.Repo.Datastore(), node.DAG)
-	}
-	node.Resolver = &path.Resolver{DAG: node.DAG}
-	success = true
-	return node, nil
-}
-
-func Offline(r repo.Repo) ConfigOption {
-	return Standard(r, false)
-}
-
-func OnlineWithRouting(r repo.Repo, router routing.IpfsRouting) ConfigOption {
-	if router == nil {
-		panic("router required")
-	}
-	return standardWithRouting(r, true, router)
-}
-
-func Online(r repo.Repo) ConfigOption {
-	return Standard(r, true)
-}
-
-// DEPRECATED: use Online, Offline functions
-func Standard(r repo.Repo, online bool) ConfigOption {
-	return standardWithRouting(r, online, nil)
-}
-
-// TODO refactor so maybeRouter isn't special-cased in this way
-func standardWithRouting(r repo.Repo, online bool, maybeRouter routing.IpfsRouting) ConfigOption {
-	return func(ctx context.Context) (n *IpfsNode, err error) {
-		// FIXME perform node construction in the main constructor so it isn't
-		// necessary to perform this teardown in this scope.
-		success := false
-		defer func() {
-			if !success && n != nil {
-				n.teardown()
-			}
-		}()
-
-		// TODO move as much of node initialization as possible into
-		// NewIPFSNode. The larger these config options are, the harder it is
-		// to test all node construction code paths.
-
-		if r == nil {
-			return nil, debugerror.Errorf("repo required")
-		}
-		n = &IpfsNode{
-			mode: func() mode {
-				if online {
-					return onlineMode
-				}
-				return offlineMode
-			}(),
-			Repo: r,
-		}
-
-		// setup Peerstore
-		n.Peerstore = peer.NewPeerstore()
-
-		// setup local peer ID (private key is loaded in online setup)
-		if err := n.loadID(); err != nil {
-			return nil, err
-		}
-
-		n.Blockstore, err = bstore.WriteCached(bstore.NewBlockstore(n.Repo.Datastore()), kSizeBlockstoreWriteCache)
-		if err != nil {
-			return nil, debugerror.Wrap(err)
-		}
-
-		if online {
-			if err := n.startOnlineServices(ctx, maybeRouter); err != nil {
-				return nil, err
-			}
-		} else {
-			n.Exchange = offline.Exchange(n.Blockstore)
-		}
-
-		success = true
-		return n, nil
-	}
-}
-
-func (n *IpfsNode) startOnlineServices(ctx context.Context, maybeRouter routing.IpfsRouting) error {
+func (n *IpfsNode) startOnlineServices(ctx context.Context, maybeRouter routing.IpfsRouting, nso NetworkSetupOption) error {
 
 	if n.PeerHost != nil { // already online.
 		return debugerror.New("node already online")
@@ -226,7 +70,8 @@ func (n *IpfsNode) startOnlineServices(ctx context.Context, maybeRouter routing.
 		return err
 	}
 
-	peerhost, err := constructPeerHost(ctx, n.Identity, n.Peerstore)
+	// Construct peer host from option
+	peerhost, err := nso(ctx, n.Identity, n.Peerstore)
 	if err != nil {
 		return debugerror.Wrap(err)
 	}

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -48,7 +48,7 @@ func TestInitialization(t *testing.T) {
 			C: *c,
 			D: testutil.ThreadSafeCloserMapDatastore(),
 		}
-		n, err := NewIPFSNode(ctx, Standard(r, false))
+		n, err := NewIPFSNode(ctx, Offline(r))
 		if n == nil || err != nil {
 			t.Error("Should have constructed.", i, err)
 		}
@@ -59,7 +59,7 @@ func TestInitialization(t *testing.T) {
 			C: *c,
 			D: testutil.ThreadSafeCloserMapDatastore(),
 		}
-		n, err := NewIPFSNode(ctx, Standard(r, false))
+		n, err := NewIPFSNode(ctx, Offline(r))
 		if n != nil || err == nil {
 			t.Error("Should have failed to construct.", i)
 		}

--- a/core/node.go
+++ b/core/node.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"io"
+
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
+	ctxgroup "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-ctxgroup"
+
+	debugerror "github.com/jbenet/go-ipfs/util/debugerror"
+
+	diag "github.com/jbenet/go-ipfs/diagnostics"
+	ic "github.com/jbenet/go-ipfs/p2p/crypto"
+	p2phost "github.com/jbenet/go-ipfs/p2p/host"
+	peer "github.com/jbenet/go-ipfs/p2p/peer"
+
+	routing "github.com/jbenet/go-ipfs/routing"
+
+	bstore "github.com/jbenet/go-ipfs/blocks/blockstore"
+	bserv "github.com/jbenet/go-ipfs/blockservice"
+	exchange "github.com/jbenet/go-ipfs/exchange"
+	rp "github.com/jbenet/go-ipfs/exchange/reprovide"
+
+	merkledag "github.com/jbenet/go-ipfs/merkledag"
+	namesys "github.com/jbenet/go-ipfs/namesys"
+	path "github.com/jbenet/go-ipfs/path"
+	pin "github.com/jbenet/go-ipfs/pin"
+	repo "github.com/jbenet/go-ipfs/repo"
+)
+
+// IpfsNode is IPFS Core module. It represents an IPFS instance.
+type IpfsNode struct {
+
+	// Self
+	Identity peer.ID // the local node's identity
+
+	Repo repo.Repo
+
+	// Local node
+	Pinning    pin.Pinner // the pinning manager
+	Mounts     Mounts     // current mount state, if any.
+	PrivateKey ic.PrivKey // the local node's private Key
+
+	// Services
+	Peerstore  peer.Peerstore       // storage for other Peer instances
+	Blockstore bstore.Blockstore    // the block store (lower level)
+	Blocks     *bserv.BlockService  // the block service, get/add blocks.
+	DAG        merkledag.DAGService // the merkle dag service, get/add objects.
+	Resolver   *path.Resolver       // the path resolution system
+
+	// Online
+	PeerHost     p2phost.Host        // the network host (server+client)
+	Bootstrapper io.Closer           // the periodic bootstrapper
+	Routing      routing.IpfsRouting // the routing system. recommend ipfs-dht
+	Exchange     exchange.Interface  // the block exchange + strategy (bitswap)
+	Namesys      namesys.NameSystem  // the name system, resolves paths to hashes
+	Diagnostics  *diag.Diagnostics   // the diagnostics service
+	Reprovider   *rp.Reprovider      // the value reprovider system
+
+	ctxgroup.ContextGroup
+
+	mode mode
+}
+
+// NewIPFSNode is the main constructor used to create an ipfs instance
+func NewIPFSNode(parent context.Context, option ConfigOption) (*IpfsNode, error) {
+	ctxg := ctxgroup.WithContext(parent)
+	ctx := ctxg.Context()
+	success := false // flip to true after all sub-system inits succeed
+	defer func() {
+		if !success {
+			ctxg.Close()
+		}
+	}()
+
+	node, err := option(ctx)
+	if err != nil {
+		return nil, err
+	}
+	node.ContextGroup = ctxg
+	ctxg.SetTeardown(node.teardown)
+
+	// Need to make sure it's perfectly clear 1) which variables are expected
+	// to be initialized at this point, and 2) which variables will be
+	// initialized after this point.
+
+	node.Blocks, err = bserv.New(node.Blockstore, node.Exchange)
+	if err != nil {
+		return nil, debugerror.Wrap(err)
+	}
+	if node.Peerstore == nil {
+		node.Peerstore = peer.NewPeerstore()
+	}
+	node.DAG = merkledag.NewDAGService(node.Blocks)
+	node.Pinning, err = pin.LoadPinner(node.Repo.Datastore(), node.DAG)
+	if err != nil {
+		node.Pinning = pin.NewPinner(node.Repo.Datastore(), node.DAG)
+	}
+	node.Resolver = &path.Resolver{DAG: node.DAG}
+	success = true
+	return node, nil
+}

--- a/core/options.go
+++ b/core/options.go
@@ -1,0 +1,94 @@
+package core
+
+import (
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
+
+	debugerror "github.com/jbenet/go-ipfs/util/debugerror"
+
+	p2phost "github.com/jbenet/go-ipfs/p2p/host"
+	peer "github.com/jbenet/go-ipfs/p2p/peer"
+
+	routing "github.com/jbenet/go-ipfs/routing"
+
+	bstore "github.com/jbenet/go-ipfs/blocks/blockstore"
+	offline "github.com/jbenet/go-ipfs/exchange/offline"
+
+	repo "github.com/jbenet/go-ipfs/repo"
+)
+
+type ConfigOption func(ctx context.Context) (*IpfsNode, error)
+type NetworkSetupOption func(context.Context, peer.ID, peer.Peerstore) (p2phost.Host, error)
+
+// Offline returns an IpfsNode ConfigOption for an instance in offline mode
+func Offline(r repo.Repo) ConfigOption {
+	return standardWithRouting(r, false, nil)
+}
+
+// OnlineWithRouting returns an IpfsNode ConfigOption for an instance in offline mode
+// but with the option of specifying the routing system to be used.
+func OnlineWithRouting(r repo.Repo, router routing.IpfsRouting) ConfigOption {
+	if router == nil {
+		panic("router required")
+	}
+	return standardWithRouting(r, true, router)
+}
+
+// Offline returns an IpfsNode ConfigOption for an instance in online mode
+func Online(r repo.Repo) ConfigOption {
+	return standardWithRouting(r, true, nil)
+}
+
+// TODO refactor so maybeRouter isn't special-cased in this way
+func standardWithRouting(r repo.Repo, online bool, maybeRouter routing.IpfsRouting) ConfigOption {
+	return func(ctx context.Context) (n *IpfsNode, err error) {
+		// FIXME perform node construction in the main constructor so it isn't
+		// necessary to perform this teardown in this scope.
+		success := false
+		defer func() {
+			if !success && n != nil {
+				n.teardown()
+			}
+		}()
+
+		// TODO move as much of node initialization as possible into
+		// NewIPFSNode. The larger these config options are, the harder it is
+		// to test all node construction code paths.
+
+		if r == nil {
+			return nil, debugerror.Errorf("repo required")
+		}
+		n = &IpfsNode{
+			mode: func() mode {
+				if online {
+					return onlineMode
+				}
+				return offlineMode
+			}(),
+			Repo: r,
+		}
+
+		// setup Peerstore
+		n.Peerstore = peer.NewPeerstore()
+
+		// setup local peer ID (private key is loaded in online setup)
+		if err := n.loadID(); err != nil {
+			return nil, err
+		}
+
+		n.Blockstore, err = bstore.WriteCached(bstore.NewBlockstore(n.Repo.Datastore()), kSizeBlockstoreWriteCache)
+		if err != nil {
+			return nil, debugerror.Wrap(err)
+		}
+
+		if online {
+			if err := n.startOnlineServices(ctx, maybeRouter, constructPeerHost); err != nil {
+				return nil, err
+			}
+		} else {
+			n.Exchange = offline.Exchange(n.Blockstore)
+		}
+
+		success = true
+		return n, nil
+	}
+}

--- a/p2p/net/gen/gen.go
+++ b/p2p/net/gen/gen.go
@@ -1,0 +1,47 @@
+package gen
+
+import (
+	"fmt"
+
+	ic "github.com/jbenet/go-ipfs/p2p/crypto"
+	host "github.com/jbenet/go-ipfs/p2p/host"
+	bhost "github.com/jbenet/go-ipfs/p2p/host/basic"
+	swarm "github.com/jbenet/go-ipfs/p2p/net/swarm"
+	peer "github.com/jbenet/go-ipfs/p2p/peer"
+
+	ma "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
+
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
+)
+
+type NetGenerator interface {
+	AddPeer(pri ic.PrivKey, pid peer.ID) (host.Host, error)
+}
+
+type realNetGenerator struct {
+	beginPort int
+	ctx       context.Context
+}
+
+func NewNetGenerator(ctx context.Context) NetGenerator {
+	return &realNetGenerator{
+		beginPort: 10000,
+	}
+}
+
+func (rng *realNetGenerator) AddPeer(pri ic.PrivKey, pid peer.ID) (host.Host, error) {
+	pstore := peer.NewPeerstore()
+	err := pstore.AddPrivKey(pid, pri)
+	if err != nil {
+		return nil, err
+	}
+	addr := ma.StringCast(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", rng.beginPort))
+	net, err := swarm.NewNetwork(rng.ctx, []ma.Multiaddr{addr}, pid, pstore)
+	if err != nil {
+		return nil, err
+	}
+
+	rng.beginPort++
+
+	return bhost.New(net), nil
+}


### PR DESCRIPTION
Im working on refactoring core a little bit. All ive done so far is to break it into separate files. My goal is to be able to pass in my own network object (see the NetworkGenerator interface) so i can make dhthell run easily on a mocknet OR a real net. @briantigerchow Feel free to push to this branch any changes you like, since i trust your intuition on interfaces far more than my own.

Oh yeah, WIP