### PR TITLE
ratelimiter: fixing rate limiter use

### DIFF
--- a/blockservice/worker/worker.go
+++ b/blockservice/worker/worker.go
@@ -117,11 +117,10 @@ func (w *Worker) start(c Config) {
 		}
 	})
 
-	// reads from |workerChan| until process closes
-	w.process.Go(func(proc process.Process) {
+	// reads from |workerChan| until w.process closes
+	limiter := ratelimit.NewRateLimiter(w.process, c.NumWorkers)
+	limiter.Go(func(proc process.Process) {
 		ctx := waitable.Context(proc) // shut down in-progress HasBlock when time to die
-		limiter := ratelimit.NewRateLimiter(process.Background(), c.NumWorkers)
-		defer limiter.Close()
 		for {
 			select {
 			case <-proc.Closing():


### PR DESCRIPTION
Use of the ratelimiter should be conscious of the ratelimiter's
potential closing. any loops that add work to ratelimiter
should (a) only do so if the rate limiter is not closed,
or (b) prevent limiter while work is added
(i.e. use limiter.Go(addWorkHere))