### PR TITLE
have repo tilde expand paths

### DIFF
--- a/repo/fsrepo/fsrepo.go
+++ b/repo/fsrepo/fsrepo.go
@@ -16,6 +16,7 @@ import (
 	lockfile "github.com/jbenet/go-ipfs/repo/fsrepo/lock"
 	serialize "github.com/jbenet/go-ipfs/repo/fsrepo/serialize"
 	dir "github.com/jbenet/go-ipfs/thirdparty/dir"
+	u "github.com/jbenet/go-ipfs/util"
 	debugerror "github.com/jbenet/go-ipfs/util/debugerror"
 )
 
@@ -144,6 +145,12 @@ func (r *FSRepo) Open() error {
 	// and the number of openers is incremeneted.
 	packageLock.Lock()
 	defer packageLock.Unlock()
+
+	expPath, err := u.TildeExpansion(r.path)
+	if err != nil {
+		return err
+	}
+	r.path = expPath
 
 	if r.state != unopened {
 		return debugerror.Errorf("repo is %s", r.state)


### PR DESCRIPTION
As I work through examples, I feel like it would be much easier for the fsrepo to tilde expand paths given to it. This makes it much easier for users to write the following code:
```
r := fsrepo.At("~/.go-ipfs")
```
instead of:
```
home := os.GetEnv("HOME")
if len(home) == 0 {
    panic("WHAT IS HAPPENING?")
}
r := fsrepo.At(home + "/.go-ipfs")
```