### PR TITLE
fix a panic caused by context cancelling closing a promise channel

### DIFF
--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -151,7 +151,15 @@ func (bs *bitswap) GetBlock(parent context.Context, k u.Key) (*blocks.Block, err
 	}
 
 	select {
-	case block := <-promise:
+	case block, ok := <-promise:
+		if !ok {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+				return nil, errors.New("promise channel was closed")
+			}
+		}
 		return block, nil
 	case <-parent.Done():
 		return nil, parent.Err()


### PR DESCRIPTION
I got this panic:
```
2015/02/12 19:05:18 http: panic serving 127.0.0.1:56989: runtime error: invalid memory address or nil pointer dereference
goroutine 38133 [running]:
net/http.funcÂ·012()
	/home/whyrusleeping/go/src/net/http/server.go:1187 +0xb8
github.com/jbenet/go-ipfs/merkledag.(*dagService).Get(0x11632f20, 0x11cc7b30, 0x22, 0x11cc7b30, 0x0, 0x0)
	/home/whyrusleeping/gopkg/src/github.com/jbenet/go-ipfs/merkledag/merkledag.go:102 +0x160
github.com/jbenet/go-ipfs/path.(*Resolver).ResolvePathComponents(0x11632758, 0x11e66325, 0x2e, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/whyrusleeping/gopkg/src/github.com/jbenet/go-ipfs/path/resolver.go:77 +0x1cc
github.com/jbenet/go-ipfs/path.(*Resolver).ResolvePath(0x11632758, 0x11e66325, 0x2e, 0x1, 0x0, 0x0)
	/home/whyrusleeping/gopkg/src/github.com/jbenet/go-ipfs/path/resolver.go:59 +0x44
github.com/jbenet/go-ipfs/core/commands.cat(0xb6dd9c10, 0x11e64c80, 0x10c463f0, 0x115f5468, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, ...)
	/home/whyrusleeping/gopkg/src/github.com/jbenet/go-ipfs/core/commands/cat.go:65 +0x13c
github.com/jbenet/go-ipfs/core/commands.funcÂ·014(0xb6dd7698, 0x11608840, 0xb6dd7770, 0x10f49440)
	/home/whyrusleeping/gopkg/src/github.com/jbenet/go-ipfs/core/commands/cat.go:36 +0x118
github.com/jbenet/go-ipfs/commands.(*Command).Call(0x9bc098, 0xb6dd7698, 0x11608840, 0x0, 0x0)
	/home/whyrusleeping/gopkg/src/github.com/jbenet/go-ipfs/commands/command.go:98 +0x424
github.com/jbenet/go-ipfs/commands/http.Handler.ServeHTTP(0xb6dd9c10, 0x11e64c80, 0x0, 0x10c28700, 0x1c, 0x10c740b0, 0x7afd3c, 0x0, 0x11632fe0, 0x9bc098, ...)
	/home/whyrusleeping/gopkg/src/github.com/jbenet/go-ipfs/commands/http/handler.go:91 +0x6d8
github.com/jbenet/go-ipfs/commands/http.(*Handler).ServeHTTP(0x115880f0, 0xb6ddda90, 0x10f1d780, 0x11e662a0)
	<autogenerated>:2 +0xc8
net/http.(*ServeMux).ServeHTTP(0x1161aa20, 0xb6ddda90, 0x10f1d780, 0x11e662a0)
	/home/whyrusleeping/go/src/net/http/server.go:1598 +0x19c
net/http.serverHandler.ServeHTTP(0x10c2e37c, 0xb6ddda90, 0x10f1d780, 0x11e662a0)
	/home/whyrusleeping/go/src/net/http/server.go:1760 +0x1b0
net/http.(*conn).serve(0x115f97a0)
	/home/whyrusleeping/go/src/net/http/server.go:1274 +0xb18
created by net/http.(*Server).Serve
	/home/whyrusleeping/go/src/net/http/server.go:1808 +0x34c
```

And i beleive this was the cause:
```
14:50:20 whyrusleeping | if the context is cancelled while a GetBlocks request is going on, the promise from the notifications can be closed, causing a nil block to be received from it *before* we notice the context has been closed in GetBlock     
14:50:32 whyrusleeping | causing us to return nil, nil erroneously                                                              
14:50:36 whyrusleeping | and thus, that panic                                                                                                                                                  
14:51:00 whyrusleeping | probably something we will only ever see under high load
```