### PR TITLE
add dial and listen methods to the core for super awesomeness

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -235,9 +235,6 @@ func (n *IpfsNode) startOnlineServices(ctx context.Context, routingOption Routin
 		return err
 	}
 
-	// Wrap standard peer host with routing system to allow unknown peer lookups
-	n.PeerHost = rhost.Wrap(peerhost, n.Routing)
-
 	// Ok, now we're ready to listen.
 	if err := startListening(ctx, n.PeerHost, n.Repo.Config()); err != nil {
 		return debugerror.Wrap(err)
@@ -252,6 +249,9 @@ func (n *IpfsNode) startOnlineServices(ctx context.Context, routingOption Routin
 // startOnlineServicesWithHost  is the set of services which need to be
 // initialized with the host and _before_ we start listening.
 func (n *IpfsNode) startOnlineServicesWithHost(ctx context.Context, host p2phost.Host, routingOption RoutingOption) error {
+	// Wrap standard peer host with routing system to allow unknown peer lookups
+	n.PeerHost = rhost.Wrap(host, n.Routing)
+
 	// setup diagnostics service
 	n.Diagnostics = diag.NewDiagnostics(n.Identity, host)
 
@@ -264,7 +264,7 @@ func (n *IpfsNode) startOnlineServicesWithHost(ctx context.Context, host p2phost
 
 	// setup exchange service
 	const alwaysSendToPeer = true // use YesManStrategy
-	bitswapNetwork := bsnet.NewFromIpfsHost(host, n.Routing)
+	bitswapNetwork := bsnet.NewFromIpfsHost(n.PeerHost, n.Routing)
 	n.Exchange = bitswap.New(ctx, n.Identity, bitswapNetwork, n.Blockstore, alwaysSendToPeer)
 
 	// setup name system

--- a/core/core.go
+++ b/core/core.go
@@ -21,6 +21,7 @@ import (
 	ic "github.com/jbenet/go-ipfs/p2p/crypto"
 	p2phost "github.com/jbenet/go-ipfs/p2p/host"
 	p2pbhost "github.com/jbenet/go-ipfs/p2p/host/basic"
+	rhost "github.com/jbenet/go-ipfs/p2p/host/routed"
 	swarm "github.com/jbenet/go-ipfs/p2p/net/swarm"
 	addrutil "github.com/jbenet/go-ipfs/p2p/net/swarm/addr"
 	peer "github.com/jbenet/go-ipfs/p2p/peer"
@@ -235,6 +236,8 @@ func (n *IpfsNode) startOnlineServices(ctx context.Context, routingOption Routin
 	if err := n.startOnlineServicesWithHost(ctx, routingOption); err != nil {
 		return err
 	}
+
+	n.PeerHost = rhost.Wrap(peerhost, n.Routing)
 
 	// Ok, now we're ready to listen.
 	if err := startListening(ctx, n.PeerHost, n.Repo.Config()); err != nil {

--- a/core/corenet/net.go
+++ b/core/corenet/net.go
@@ -1,6 +1,8 @@
 package corenet
 
 import (
+	"time"
+
 	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
 	core "github.com/jbenet/go-ipfs/core"
 	net "github.com/jbenet/go-ipfs/p2p/net"
@@ -52,5 +54,10 @@ func Listen(nd *core.IpfsNode, protocol string) (*ipfsListener, error) {
 }
 
 func Dial(nd *core.IpfsNode, p peer.ID, protocol string) (net.Stream, error) {
+	ctx, _ := context.WithTimeout(nd.Context(), time.Second*30)
+	err := nd.PeerHost.Connect(ctx, peer.PeerInfo{ID: p})
+	if err != nil {
+		return nil, err
+	}
 	return nd.PeerHost.NewStream(pro.ID(protocol), p)
 }

--- a/core/corenet/net.go
+++ b/core/corenet/net.go
@@ -1,14 +1,14 @@
-package core
+package corenet
 
 import (
 	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
+	core "github.com/jbenet/go-ipfs/core"
 	net "github.com/jbenet/go-ipfs/p2p/net"
 	peer "github.com/jbenet/go-ipfs/p2p/peer"
 	pro "github.com/jbenet/go-ipfs/p2p/protocol"
 )
 
 type ipfsListener struct {
-	nd     *IpfsNode
 	conCh  chan net.Stream
 	proto  pro.ID
 	ctx    context.Context
@@ -30,7 +30,7 @@ func (il *ipfsListener) Close() error {
 	return nil
 }
 
-func (nd *IpfsNode) Listen(protocol string) (*ipfsListener, error) {
+func Listen(nd *core.IpfsNode, protocol string) (*ipfsListener, error) {
 	ctx, cancel := context.WithCancel(nd.Context())
 
 	list := &ipfsListener{
@@ -51,6 +51,6 @@ func (nd *IpfsNode) Listen(protocol string) (*ipfsListener, error) {
 	return list, nil
 }
 
-func (nd *IpfsNode) Dial(protocol string, p peer.ID) (net.Stream, error) {
+func Dial(nd *core.IpfsNode, p peer.ID, protocol string) (net.Stream, error) {
 	return nd.PeerHost.NewStream(pro.ID(protocol), p)
 }

--- a/core/net.go
+++ b/core/net.go
@@ -1,0 +1,56 @@
+package core
+
+import (
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
+	net "github.com/jbenet/go-ipfs/p2p/net"
+	peer "github.com/jbenet/go-ipfs/p2p/peer"
+	pro "github.com/jbenet/go-ipfs/p2p/protocol"
+)
+
+type ipfsListener struct {
+	nd     *IpfsNode
+	conCh  chan net.Stream
+	proto  pro.ID
+	ctx    context.Context
+	cancel func()
+}
+
+func (il *ipfsListener) Accept() (net.Stream, error) {
+	select {
+	case c := <-il.conCh:
+		return c, nil
+	case <-il.ctx.Done():
+		return nil, il.ctx.Err()
+	}
+}
+
+func (il *ipfsListener) Close() error {
+	il.cancel()
+	// TODO: unregister handler from peerhost
+	return nil
+}
+
+func (nd *IpfsNode) Listen(protocol string) (*ipfsListener, error) {
+	ctx, cancel := context.WithCancel(nd.Context())
+
+	list := &ipfsListener{
+		proto:  pro.ID(protocol),
+		conCh:  make(chan net.Stream),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	nd.PeerHost.SetStreamHandler(list.proto, func(s net.Stream) {
+		select {
+		case list.conCh <- s:
+		case <-ctx.Done():
+			s.Close()
+		}
+	})
+
+	return list, nil
+}
+
+func (nd *IpfsNode) Dial(protocol string, p peer.ID) (net.Stream, error) {
+	return nd.PeerHost.NewStream(pro.ID(protocol), p)
+}

--- a/p2p/host/basic/basic_host.go
+++ b/p2p/host/basic/basic_host.go
@@ -118,6 +118,10 @@ func (h *BasicHost) SetStreamHandler(pid protocol.ID, handler inet.StreamHandler
 	h.Mux().SetHandler(pid, handler)
 }
 
+func (h *BasicHost) RemoveStreamHandler(pid protocol.ID) {
+	h.Mux().RemoveHandler(pid)
+}
+
 // NewStream opens a new stream to given peer p, and writes a p2p/protocol
 // header with given protocol.ID. If there is no connection to p, attempts
 // to create one. If ProtocolID is "", writes no header.

--- a/p2p/host/host.go
+++ b/p2p/host/host.go
@@ -46,6 +46,10 @@ type Host interface {
 	// (Threadsafe)
 	SetStreamHandler(pid protocol.ID, handler inet.StreamHandler)
 
+	// RemoveStreamHandler removes a handler on the mux that was set by
+	// SetStreamHandler
+	RemoveStreamHandler(pid protocol.ID)
+
 	// NewStream opens a new stream to given peer p, and writes a p2p/protocol
 	// header with given protocol.ID. If there is no connection to p, attempts
 	// to create one. If ProtocolID is "", writes no header.

--- a/p2p/host/routed/routed.go
+++ b/p2p/host/routed/routed.go
@@ -1,0 +1,108 @@
+package routedhost
+
+import (
+	"fmt"
+	"time"
+
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
+	ma "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multiaddr"
+
+	eventlog "github.com/jbenet/go-ipfs/thirdparty/eventlog"
+	lgbl "github.com/jbenet/go-ipfs/util/eventlog/loggables"
+
+	host "github.com/jbenet/go-ipfs/p2p/host"
+	inet "github.com/jbenet/go-ipfs/p2p/net"
+	peer "github.com/jbenet/go-ipfs/p2p/peer"
+	protocol "github.com/jbenet/go-ipfs/p2p/protocol"
+	routing "github.com/jbenet/go-ipfs/routing"
+)
+
+var log = eventlog.Logger("p2p/host/routed")
+
+// AddressTTL is the expiry time for our addresses.
+// We expire them quickly.
+const AddressTTL = time.Second * 10
+
+// RoutedHost is a p2p Host that includes a routing system.
+// This allows the Host to find the addresses for peers when
+// it does not have them.
+type RoutedHost struct {
+	host  host.Host // embedded other host.
+	route routing.IpfsRouting
+}
+
+func Wrap(h host.Host, r routing.IpfsRouting) *RoutedHost {
+	return &RoutedHost{h, r}
+}
+
+// Connect ensures there is a connection between this host and the peer with
+// given peer.ID. See (host.Host).Connect for more information.
+//
+// RoutedHost's Connect differs in that if the host has no addresses for a
+// given peer, it will use its routing system to try to find some.
+func (rh *RoutedHost) Connect(ctx context.Context, pi peer.PeerInfo) error {
+	// first, check if we're already connected.
+	if len(rh.Network().ConnsToPeer(pi.ID)) > 0 {
+		return nil
+	}
+
+	// if we were given some addresses, keep + use them.
+	if len(pi.Addrs) > 0 {
+		rh.Peerstore().AddAddrs(pi.ID, pi.Addrs, peer.TempAddrTTL)
+	}
+
+	// Check if we have some addresses in our recent memory.
+	addrs := rh.Peerstore().Addrs(pi.ID)
+	if len(addrs) < 1 {
+
+		// no addrs? find some with the routing system.
+		pi2, err := rh.route.FindPeer(ctx, pi.ID)
+		if err != nil {
+			return err // couldnt find any :(
+		}
+		if pi2.ID != pi.ID {
+			err = fmt.Errorf("routing failure: provided addrs for different peer")
+			logRoutingErrDifferentPeers(ctx, pi.ID, pi2.ID, err)
+			return err
+		}
+		addrs = pi2.Addrs
+	}
+
+	// if we're here, we got some addrs. let's use our wrapped host to connect.
+	pi.Addrs = addrs
+	return rh.host.Connect(ctx, pi)
+}
+
+func logRoutingErrDifferentPeers(ctx context.Context, wanted, got peer.ID, err error) {
+	lm := make(lgbl.DeferredMap)
+	lm["error"] = err
+	lm["wantedPeer"] = func() interface{} { return wanted.Pretty() }
+	lm["gotPeer"] = func() interface{} { return got.Pretty() }
+	log.Event(ctx, "routingError", lm)
+}
+
+func (rh *RoutedHost) ID() peer.ID {
+	return rh.host.ID()
+}
+func (rh *RoutedHost) Peerstore() peer.Peerstore {
+	return rh.host.Peerstore()
+}
+func (rh *RoutedHost) Addrs() []ma.Multiaddr {
+	return rh.host.Addrs()
+}
+func (rh *RoutedHost) Network() inet.Network {
+	return rh.host.Network()
+}
+func (rh *RoutedHost) Mux() *protocol.Mux {
+	return rh.host.Mux()
+}
+func (rh *RoutedHost) SetStreamHandler(pid protocol.ID, handler inet.StreamHandler) {
+	rh.host.SetStreamHandler(pid, handler)
+}
+func (rh *RoutedHost) NewStream(pid protocol.ID, p peer.ID) (inet.Stream, error) {
+	return rh.host.NewStream(pid, p)
+}
+func (rh *RoutedHost) Close() error {
+	// no need to close IpfsRouting. we dont own it.
+	return rh.host.Close()
+}

--- a/p2p/host/routed/routed.go
+++ b/p2p/host/routed/routed.go
@@ -100,6 +100,14 @@ func (rh *RoutedHost) SetStreamHandler(pid protocol.ID, handler inet.StreamHandl
 	rh.host.SetStreamHandler(pid, handler)
 }
 func (rh *RoutedHost) NewStream(pid protocol.ID, p peer.ID) (inet.Stream, error) {
+	if len(rh.Peerstore().Addrs(p)) < 1 {
+		ctx, _ := context.WithTimeout(context.TODO(), time.Second*30)
+		pi, err := rh.route.FindPeer(ctx, p)
+		if err != nil {
+			return nil, err
+		}
+		rh.Peerstore().AddAddrs(p, pi.Addrs, peer.TempAddrTTL)
+	}
 	return rh.host.NewStream(pid, p)
 }
 func (rh *RoutedHost) Close() error {

--- a/p2p/host/routed/routed.go
+++ b/p2p/host/routed/routed.go
@@ -84,21 +84,31 @@ func logRoutingErrDifferentPeers(ctx context.Context, wanted, got peer.ID, err e
 func (rh *RoutedHost) ID() peer.ID {
 	return rh.host.ID()
 }
+
 func (rh *RoutedHost) Peerstore() peer.Peerstore {
 	return rh.host.Peerstore()
 }
+
 func (rh *RoutedHost) Addrs() []ma.Multiaddr {
 	return rh.host.Addrs()
 }
+
 func (rh *RoutedHost) Network() inet.Network {
 	return rh.host.Network()
 }
+
 func (rh *RoutedHost) Mux() *protocol.Mux {
 	return rh.host.Mux()
 }
+
 func (rh *RoutedHost) SetStreamHandler(pid protocol.ID, handler inet.StreamHandler) {
 	rh.host.SetStreamHandler(pid, handler)
 }
+
+func (rh *RoutedHost) RemoveStreamHandler(pid protocol.ID) {
+	rh.host.RemoveStreamHandler(pid)
+}
+
 func (rh *RoutedHost) NewStream(pid protocol.ID, p peer.ID) (inet.Stream, error) {
 	return rh.host.NewStream(pid, p)
 }

--- a/p2p/host/routed/routed.go
+++ b/p2p/host/routed/routed.go
@@ -100,14 +100,6 @@ func (rh *RoutedHost) SetStreamHandler(pid protocol.ID, handler inet.StreamHandl
 	rh.host.SetStreamHandler(pid, handler)
 }
 func (rh *RoutedHost) NewStream(pid protocol.ID, p peer.ID) (inet.Stream, error) {
-	if len(rh.Peerstore().Addrs(p)) < 1 {
-		ctx, _ := context.WithTimeout(context.TODO(), time.Second*30)
-		pi, err := rh.route.FindPeer(ctx, p)
-		if err != nil {
-			return nil, err
-		}
-		rh.Peerstore().AddAddrs(p, pi.Addrs, peer.TempAddrTTL)
-	}
 	return rh.host.NewStream(pid, p)
 }
 func (rh *RoutedHost) Close() error {

--- a/p2p/protocol/mux.go
+++ b/p2p/protocol/mux.go
@@ -90,6 +90,15 @@ func (m *Mux) SetHandler(p ID, h inet.StreamHandler) {
 	m.lock.Unlock()
 }
 
+// RemoveHandler removes the protocol handler on the Network's Muxer.
+// This operation is threadsafe.
+func (m *Mux) RemoveHandler(p ID) {
+	log.Debugf("%s removing handler for protocol: %s (%d)", m, p, len(p))
+	m.lock.Lock()
+	delete(m.handlers, p)
+	m.lock.Unlock()
+}
+
 // Handle reads the next name off the Stream, and calls a handler function
 // This is done in its own goroutine, to avoid blocking the caller.
 func (m *Mux) Handle(s inet.Stream) {

--- a/test/integration/core.go
+++ b/test/integration/core.go
@@ -4,7 +4,6 @@ import (
 	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
 	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore"
 	syncds "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-datastore/sync"
-	ds2 "github.com/jbenet/go-ipfs/util/datastore2"
 	blockstore "github.com/jbenet/go-ipfs/blocks/blockstore"
 	core "github.com/jbenet/go-ipfs/core"
 	bitswap "github.com/jbenet/go-ipfs/exchange/bitswap"
@@ -14,6 +13,7 @@ import (
 	"github.com/jbenet/go-ipfs/repo"
 	delay "github.com/jbenet/go-ipfs/thirdparty/delay"
 	eventlog "github.com/jbenet/go-ipfs/thirdparty/eventlog"
+	ds2 "github.com/jbenet/go-ipfs/util/datastore2"
 	testutil "github.com/jbenet/go-ipfs/util/testutil"
 )
 
@@ -35,7 +35,7 @@ func MocknetTestRepo(p peer.ID, h host.Host, conf testutil.LatencyConfig, routin
 			PeerHost:  h,
 			Identity:  p,
 		}
-		dhtt, err := routing(ctx, n)
+		dhtt, err := routing(ctx, n.PeerHost, n.Repo.Datastore())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
@jbenet tell me what you think of this. I wanted to write code like this:
```
list, err := nd.Listen("/myapp")
for {
    con, err := list.Accept()
    go handleConnection(con)
}
```

I had a few cool example ipfs apps that i wanted to write using this, but it was ugly (but still very easily possible) without this abstraction.