### PR TITLE
Feat/reprov worker

### DIFF
--- a/blocks/blocks.go
+++ b/blocks/blocks.go
@@ -42,3 +42,9 @@ func (b *Block) Key() u.Key {
 func (b *Block) String() string {
 	return fmt.Sprintf("[Block %s]", b.Key())
 }
+
+func (b *Block) Loggable() map[string]interface{} {
+	return map[string]interface{}{
+		"block": b.Key().String(),
+	}
+}

--- a/exchange/bitswap/notifications/notifications_test.go
+++ b/exchange/bitswap/notifications/notifications_test.go
@@ -76,6 +76,30 @@ func TestSubscribeMany(t *testing.T) {
 	assertBlocksEqual(t, e2, r2)
 }
 
+// TestDuplicateSubscribe tests a scenario where a given block
+// would be requested twice at the same time.
+func TestDuplicateSubscribe(t *testing.T) {
+	e1 := blocks.NewBlock([]byte("1"))
+
+	n := New()
+	defer n.Shutdown()
+	ch1 := n.Subscribe(context.Background(), e1.Key())
+	ch2 := n.Subscribe(context.Background(), e1.Key())
+
+	n.Publish(e1)
+	r1, ok := <-ch1
+	if !ok {
+		t.Fatal("didn't receive first expected block")
+	}
+	assertBlocksEqual(t, e1, r1)
+
+	r2, ok := <-ch2
+	if !ok {
+		t.Fatal("didn't receive second expected block")
+	}
+	assertBlocksEqual(t, e1, r2)
+}
+
 func TestSubscribeIsANoopWhenCalledWithNoKeys(t *testing.T) {
 	n := New()
 	defer n.Shutdown()

--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -1,0 +1,133 @@
+package bitswap
+
+import (
+	"time"
+
+	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/go.net/context"
+	inflect "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/briantigerchow/inflect"
+	process "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/goprocess"
+)
+
+func (bs *bitswap) startWorkers(px process.Process, ctx context.Context) {
+	// Start up a worker to handle block requests this node is making
+	px.Go(func(px process.Process) {
+		bs.clientWorker(ctx)
+	})
+
+	// Start up a worker to handle requests from other nodes for the data on this node
+	px.Go(func(px process.Process) {
+		bs.taskWorker(ctx)
+	})
+
+	// Start up a worker to manage periodically resending our wantlist out to peers
+	px.Go(func(px process.Process) {
+		bs.rebroadcastWorker(ctx)
+	})
+
+	// Spawn up multiple workers to handle incoming blocks
+	// consider increasing number if providing blocks bottlenecks
+	// file transfers
+	for i := 0; i < provideWorkers; i++ {
+		px.Go(func(px process.Process) {
+			bs.blockReceiveWorker(ctx)
+		})
+	}
+}
+
+func (bs *bitswap) taskWorker(ctx context.Context) {
+	defer log.Info("bitswap task worker shutting down...")
+	for {
+		select {
+		case nextEnvelope := <-bs.engine.Outbox():
+			select {
+			case envelope, ok := <-nextEnvelope:
+				if !ok {
+					continue
+				}
+				log.Event(ctx, "deliverBlocks", envelope.Message, envelope.Peer)
+				bs.send(ctx, envelope.Peer, envelope.Message)
+			case <-ctx.Done():
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (bs *bitswap) blockReceiveWorker(ctx context.Context) {
+	for {
+		select {
+		case blk, ok := <-bs.newBlocks:
+			if !ok {
+				log.Debug("newBlocks channel closed")
+				return
+			}
+			ctx, _ := context.WithTimeout(ctx, provideTimeout)
+			err := bs.network.Provide(ctx, blk.Key())
+			if err != nil {
+				log.Error(err)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// TODO ensure only one active request per key
+func (bs *bitswap) clientWorker(parent context.Context) {
+	defer log.Info("bitswap client worker shutting down...")
+
+	for {
+		select {
+		case req := <-bs.batchRequests:
+			keys := req.keys
+			if len(keys) == 0 {
+				log.Warning("Received batch request for zero blocks")
+				continue
+			}
+			for i, k := range keys {
+				bs.wantlist.Add(k, kMaxPriority-i)
+			}
+
+			bs.wantNewBlocks(req.ctx, keys)
+
+			// NB: Optimization. Assumes that providers of key[0] are likely to
+			// be able to provide for all keys. This currently holds true in most
+			// every situation. Later, this assumption may not hold as true.
+			child, _ := context.WithTimeout(req.ctx, providerRequestTimeout)
+			providers := bs.network.FindProvidersAsync(child, keys[0], maxProvidersPerRequest)
+			err := bs.sendWantlistToPeers(req.ctx, providers)
+			if err != nil {
+				log.Debugf("error sending wantlist: %s", err)
+			}
+		case <-parent.Done():
+			return
+		}
+	}
+}
+
+func (bs *bitswap) rebroadcastWorker(parent context.Context) {
+	ctx, cancel := context.WithCancel(parent)
+	defer cancel()
+
+	broadcastSignal := time.After(rebroadcastDelay.Get())
+
+	for {
+		select {
+		case <-time.Tick(10 * time.Second):
+			n := bs.wantlist.Len()
+			if n > 0 {
+				log.Debug(n, inflect.FromNumber("keys", n), "in bitswap wantlist")
+			}
+		case <-broadcastSignal: // resend unfulfilled wantlist keys
+			entries := bs.wantlist.Entries()
+			if len(entries) > 0 {
+				bs.sendWantlistToProviders(ctx, entries)
+			}
+			broadcastSignal = time.After(rebroadcastDelay.Get())
+		case <-parent.Done():
+			return
+		}
+	}
+}

--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -29,7 +29,7 @@ func (bs *bitswap) startWorkers(px process.Process, ctx context.Context) {
 	// file transfers
 	for i := 0; i < provideWorkers; i++ {
 		px.Go(func(px process.Process) {
-			bs.blockReceiveWorker(ctx)
+			bs.provideWorker(ctx)
 		})
 	}
 }
@@ -55,7 +55,7 @@ func (bs *bitswap) taskWorker(ctx context.Context) {
 	}
 }
 
-func (bs *bitswap) blockReceiveWorker(ctx context.Context) {
+func (bs *bitswap) provideWorker(ctx context.Context) {
 	for {
 		select {
 		case blk, ok := <-bs.newBlocks:


### PR DESCRIPTION
Add a worker to provide new blocks out of the main control path to increase the speed at which we can accept incoming blocks.