### PR TITLE
move blocking calls out of single threaded loops, cancel contexts ASAP

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -249,9 +249,6 @@ func (n *IpfsNode) startOnlineServices(ctx context.Context, routingOption Routin
 // startOnlineServicesWithHost  is the set of services which need to be
 // initialized with the host and _before_ we start listening.
 func (n *IpfsNode) startOnlineServicesWithHost(ctx context.Context, host p2phost.Host, routingOption RoutingOption) error {
-	// Wrap standard peer host with routing system to allow unknown peer lookups
-	n.PeerHost = rhost.Wrap(host, n.Routing)
-
 	// setup diagnostics service
 	n.Diagnostics = diag.NewDiagnostics(n.Identity, host)
 
@@ -261,6 +258,9 @@ func (n *IpfsNode) startOnlineServicesWithHost(ctx context.Context, host p2phost
 		return debugerror.Wrap(err)
 	}
 	n.Routing = r
+
+	// Wrap standard peer host with routing system to allow unknown peer lookups
+	n.PeerHost = rhost.Wrap(host, n.Routing)
 
 	// setup exchange service
 	const alwaysSendToPeer = true // use YesManStrategy

--- a/exchange/bitswap/decision/engine.go
+++ b/exchange/bitswap/decision/engine.go
@@ -228,6 +228,10 @@ func (e *Engine) MessageSent(p peer.ID, m bsmsg.BitSwapMessage) error {
 	return nil
 }
 
+func (e *Engine) PeerDisconnected(p peer.ID) {
+	// TODO: release ledger
+}
+
 func (e *Engine) numBytesSentTo(p peer.ID) uint64 {
 	// NB not threadsafe
 	return e.findOrCreate(p).Accounting.BytesSent


### PR DESCRIPTION
This PR makes better use of contexts to cancel work that is no longer needed. It also re-introduces the ability to send wantlist updates to peers you are directly connected to. A couple other minor bugfixes are also included.