### PR TITLE
fix fuse reading on linux

### DIFF
--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -181,8 +181,11 @@ func (s *Node) Read(req *fuse.ReadRequest, resp *fuse.ReadResponse, intr fs.Intr
 	if err != nil {
 		return err
 	}
-	n, err := io.ReadFull(r, resp.Data[:req.Size])
+	n, err := r.Read(resp.Data[:req.Size])
+	if err != nil && err != io.EOF {
+		return err
+	}
 	resp.Data = resp.Data[:n]
 	lm["res_size"] = n
-	return err // may be non-nil / not succeeded
+	return nil // may be non-nil / not succeeded
 }

--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -5,6 +5,7 @@
 package readonly
 
 import (
+	"bytes"
 	"io"
 	"os"
 
@@ -181,7 +182,8 @@ func (s *Node) Read(req *fuse.ReadRequest, resp *fuse.ReadResponse, intr fs.Intr
 	if err != nil {
 		return err
 	}
-	n, err := r.Read(resp.Data[:req.Size])
+	buf := bytes.NewBuffer(resp.Data)
+	n, err := io.CopyN(buf, r, int64(req.Size))
 	if err != nil && err != io.EOF {
 		return err
 	}


### PR DESCRIPTION
In linux, fuse will try to read a 4096 block chunk,  which would cause the read call to return EOF (when the file size is less than 4096) we would return this error up to fuse, and fuse would give the user an `Input/output error`. This makes some more of the sharness tests turn green.