### PR TITLE
make wantlist updates to connected peers happen async

### DIFF
--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -368,14 +368,19 @@ func (bs *bitswap) wantNewBlocks(ctx context.Context, bkeys []u.Key) {
 	for i, k := range bkeys {
 		message.AddEntry(k, kMaxPriority-i)
 	}
+
+	wg := sync.WaitGroup{}
 	for _, p := range bs.engine.Peers() {
+		wg.Add(1)
 		go func(p peer.ID) {
+			defer wg.Done()
 			err := bs.send(ctx, p, message)
 			if err != nil {
 				log.Debugf("Error sending message: %s", err)
 			}
 		}(p)
 	}
+	wg.Wait()
 }
 
 func (bs *bitswap) ReceiveError(err error) {

--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -369,10 +369,12 @@ func (bs *bitswap) wantNewBlocks(ctx context.Context, bkeys []u.Key) {
 		message.AddEntry(k, kMaxPriority-i)
 	}
 	for _, p := range bs.engine.Peers() {
-		err := bs.send(ctx, p, message)
-		if err != nil {
-			log.Debugf("Error sending message: %s", err)
-		}
+		go func(p peer.ID) {
+			err := bs.send(ctx, p, message)
+			if err != nil {
+				log.Debugf("Error sending message: %s", err)
+			}
+		}(p)
 	}
 }
 


### PR DESCRIPTION
I spent some time debugging why the gateway nodes have been slow recently, and it came down to these sends taking a long time for certain peers. Since bitswap uses a routed peerhost, I think that some peers in the ledger werent connected to, and it was maybe trying to reconnect to them to send them a message. 