### PR TITLE
beautify 'ipfs ls' and 'ipfs object links'

### DIFF
--- a/core/commands/object.go
+++ b/core/commands/object.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"strings"
+	"text/tabwriter"
 
 	mh "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-multihash"
 
@@ -120,8 +121,11 @@ multihash.
 	Marshalers: cmds.MarshalerMap{
 		cmds.Text: func(res cmds.Response) (io.Reader, error) {
 			object := res.Output().(*Object)
-			marshalled := marshalLinks(object.Links)
-			return strings.NewReader(marshalled), nil
+			var buf bytes.Buffer
+			w := tabwriter.NewWriter(&buf, 1, 2, 1, ' ', 0)
+			marshalLinks(w, object.Links)
+			w.Flush()
+			return &buf, nil
 		},
 	},
 	Type: Object{},
@@ -246,7 +250,7 @@ var objectStatCmd = &cmds.Command{
 
 			var buf bytes.Buffer
 			w := func(s string, n int) {
-				buf.Write([]byte(fmt.Sprintf("%s: %d\n", s, n)))
+				fmt.Fprintf(&buf, "%s: %d\n", s, n)
 			}
 			w("NumLinks", ns.NumLinks)
 			w("BlockSize", ns.BlockSize)

--- a/test/sharness/t0045-ls.sh
+++ b/test/sharness/t0045-ls.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+#
+# Copyright (c) 2014 Christian Couder
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="Test ls command"
+
+. lib/test-lib.sh
+
+test_init_ipfs
+test_launch_ipfs_daemon
+
+test_expect_success "'ipfs add -r testData' succeeds" '
+	mkdir -p testData/{d1,d2}
+	echo "test" > testData/f1
+	echo "data" > testData/f2
+	echo "hello" > testData/d1/a
+	random 128 42 > testData/d1/128
+	echo "world" > testData/d2/a
+	random 1024 42 > testData/d2/1024
+	ipfs add -r testData > actual_add
+'
+
+test_expect_success "'ipfs add' output looks good" '
+	cat << EOF > expected_add
+added QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe testData/d1/128
+added QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN testData/d1/a
+added QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss testData/d1
+added QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd testData/d2/1024
+added QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL testData/d2/a
+added QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy testData/d2
+added QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH testData/f1
+added QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M testData/f2
+added QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj testData
+EOF
+	test $(diff actual_add expected_add | wc -l) -eq 0
+'
+
+test_expect_success "'ipfs ls <three dir hashes>' succeeds" '
+	ipfs ls QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss > actual_ls
+'
+
+test_expect_success "'ipfs ls <three dir hashes>' output looks good" '
+	cat << EOF > expected_ls
+QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj:
+Hash                                           Size Name 
+QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss 246  d1/  
+QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy 1143 d2/  
+QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH 13   f1   
+QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M 13   f2   
+
+QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy:
+Hash                                           Size Name 
+QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1035 1024 
+QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL 14   a    
+
+QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
+Hash                                           Size Name 
+QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 139  128  
+QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN 14   a    
+
+EOF
+	test $(diff actual_ls expected_ls | wc -l) -eq 0
+'
+
+test_kill_ipfs_daemon
+
+test_done

--- a/test/sharness/t0045-ls.sh
+++ b/test/sharness/t0045-ls.sh
@@ -11,7 +11,7 @@ test_description="Test ls command"
 test_init_ipfs
 
 test_expect_success "'ipfs add -r testData' succeeds" '
-	mkdir -p testData/{d1,d2} && \
+	mkdir testData testData/d1 testData/d2 && \
 	echo "test" > testData/f1 && \
 	echo "data" > testData/f2 && \
 	echo "hello" > testData/d1/a && \

--- a/test/sharness/t0045-ls.sh
+++ b/test/sharness/t0045-ls.sh
@@ -9,16 +9,15 @@ test_description="Test ls command"
 . lib/test-lib.sh
 
 test_init_ipfs
-test_launch_ipfs_daemon
 
 test_expect_success "'ipfs add -r testData' succeeds" '
-	mkdir -p testData/{d1,d2}
-	echo "test" > testData/f1
-	echo "data" > testData/f2
-	echo "hello" > testData/d1/a
-	random 128 42 > testData/d1/128
-	echo "world" > testData/d2/a
-	random 1024 42 > testData/d2/1024
+	mkdir -p testData/{d1,d2} && \
+	echo "test" > testData/f1 && \
+	echo "data" > testData/f2 && \
+	echo "hello" > testData/d1/a && \
+	random 128 42 > testData/d1/128 && \
+	echo "world" > testData/d2/a && \
+	random 1024 42 > testData/d2/1024 && \
 	ipfs add -r testData > actual_add
 '
 
@@ -63,7 +62,5 @@ QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN 14   a
 EOF
 	test $(diff actual_ls expected_ls | wc -l) -eq 0
 '
-
-test_kill_ipfs_daemon
 
 test_done


### PR DESCRIPTION
As discussed in #799, this PR pimps the output of `ipfs ls` and `ipfs object links` in text mode to use [text/tabwriter](https://golang.org/pkg/text/tabwriter/) which indents it nicely.

In `ipfs ls` the DAG service is used to lookup the `Data` of the node to find out it's datatype. If it is a directory, it sets the new Links `IsDir` field to true, which is then used by the text marshallers to append a `/` to the name.

I wasn't sure if we want this for `object links` as well. would be trivial to add.

before:
![before](https://cloud.githubusercontent.com/assets/111202/6404230/1e2175e0-be16-11e4-962d-a1af66ea2a17.png)

after:
![after](https://cloud.githubusercontent.com/assets/111202/6404250/59568308-be16-11e4-998e-542e4bc65493.png)

