### PR TITLE
make the providers manager respect contexts

### DIFF
--- a/routing/dht/handlers.go
+++ b/routing/dht/handlers.go
@@ -223,7 +223,7 @@ func (dht *IpfsDHT) handleAddProvider(ctx context.Context, p peer.ID, pmes *pb.M
 			// add the received addresses to our peerstore.
 			dht.peerstore.AddAddrs(pi.ID, pi.Addrs, peer.ProviderAddrTTL)
 		}
-		dht.providers.AddProvider(key, p)
+		dht.providers.AddProvider(ctx, key, p)
 	}
 
 	return pmes, nil // send back same msg as confirmation.

--- a/routing/dht/providers.go
+++ b/routing/dht/providers.go
@@ -99,10 +99,14 @@ func (pm *ProviderManager) run() {
 	}
 }
 
-func (pm *ProviderManager) AddProvider(k u.Key, val peer.ID) {
-	pm.newprovs <- &addProv{
+func (pm *ProviderManager) AddProvider(ctx context.Context, k u.Key, val peer.ID) {
+	prov := &addProv{
 		k:   k,
 		val: val,
+	}
+	select {
+	case pm.newprovs <- prov:
+	case <-ctx.Done():
 	}
 }
 

--- a/routing/dht/providers_test.go
+++ b/routing/dht/providers_test.go
@@ -14,7 +14,7 @@ func TestProviderManager(t *testing.T) {
 	mid := peer.ID("testing")
 	p := NewProviderManager(ctx, mid)
 	a := u.Key("test")
-	p.AddProvider(a, peer.ID("testingprovider"))
+	p.AddProvider(ctx, a, peer.ID("testingprovider"))
 	resp := p.GetProviders(ctx, a)
 	if len(resp) != 1 {
 		t.Fatal("Could not retrieve provider.")

--- a/routing/dht/routing.go
+++ b/routing/dht/routing.go
@@ -141,7 +141,7 @@ func (dht *IpfsDHT) Provide(ctx context.Context, key u.Key) error {
 	defer log.EventBegin(ctx, "provide", &key).Done()
 
 	// add self locally
-	dht.providers.AddProvider(key, dht.self)
+	dht.providers.AddProvider(ctx, key, dht.self)
 
 	peers, err := dht.GetClosestPeers(ctx, key)
 	if err != nil {


### PR DESCRIPTION
The send in AddProvider was hanging when routing was disabled. Making it respect the context causes the test to pass every time.