### PR TITLE
Fix nofuse build tags syntax

### DIFF
--- a/core/commands/mount_darwin.go
+++ b/core/commands/mount_darwin.go
@@ -1,3 +1,5 @@
+// +build !nofuse
+
 package commands
 
 import (

--- a/core/commands/mount_nofuse.go
+++ b/core/commands/mount_nofuse.go
@@ -1,4 +1,5 @@
-// +build (linux darwin freebsd) and nofuse
+// +build linux darwin freebsd
+// +build nofuse
 
 package commands
 

--- a/core/commands/mount_unix.go
+++ b/core/commands/mount_unix.go
@@ -1,4 +1,5 @@
-// +build (linux darwin freebsd) and !nofuse
+// +build linux darwin freebsd
+// +build !nofuse
 
 package commands
 

--- a/fuse/ipns/mount_unix.go
+++ b/fuse/ipns/mount_unix.go
@@ -1,4 +1,5 @@
-// +build (linux darwin freebsd) and !nofuse
+// +build linux darwin freebsd
+// +build !nofuse
 
 package ipns
 

--- a/fuse/readonly/mount_unix.go
+++ b/fuse/readonly/mount_unix.go
@@ -1,4 +1,5 @@
-// +build (linux darwin freebsd) and !nofuse
+// +build linux darwin freebsd
+// +build !nofuse
 
 package readonly
 

--- a/fuse/readonly/readonly_unix.go
+++ b/fuse/readonly/readonly_unix.go
@@ -1,4 +1,5 @@
-// +build (linux darwin freebsd) and !nofuse
+// +build linux darwin freebsd
+// +build !nofuse
 
 // package fuse/readonly implements a fuse filesystem to access files
 // stored inside of ipfs.


### PR DESCRIPTION
Build tag syntax only supports ` `, `,` and `!`

https://github.com/golang/go/blob/84f53339befccbb4c3449955e205a6a727282f10/src/go/build/doc.go#L73
https://github.com/golang/go/blob/84f53339befccbb4c3449955e205a6a727282f10/src/go/build/build.go#L1233