### PR TITLE
implement a worker to consolidate HasBlock provide calls into one 

### DIFF
--- a/exchange/bitswap/bitswap.go
+++ b/exchange/bitswap/bitswap.go
@@ -89,6 +89,7 @@ func New(parent context.Context, p peer.ID, network bsnet.BitSwapNetwork,
 		batchRequests: make(chan *blockRequest, sizeBatchRequestChan),
 		process:       px,
 		newBlocks:     make(chan *blocks.Block, HasBlockBufferSize),
+		provideKeys:   make(chan u.Key),
 	}
 	network.SetDelegate(bs)
 
@@ -124,6 +125,8 @@ type Bitswap struct {
 	process process.Process
 
 	newBlocks chan *blocks.Block
+
+	provideKeys chan u.Key
 }
 
 type blockRequest struct {

--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -81,7 +81,7 @@ func (bs *Bitswap) provideWorker(ctx context.Context) {
 
 func (bs *Bitswap) provideCollector(ctx context.Context) {
 	defer close(bs.provideKeys)
-	var toprovide []u.Key
+	var toProvide []u.Key
 	var nextKey u.Key
 	var keysOut chan u.Key
 
@@ -96,12 +96,12 @@ func (bs *Bitswap) provideCollector(ctx context.Context) {
 				nextKey = blk.Key()
 				keysOut = bs.provideKeys
 			} else {
-				toprovide = append(toprovide, blk.Key())
+				toProvide = append(toProvide, blk.Key())
 			}
 		case keysOut <- nextKey:
-			if len(toprovide) > 0 {
-				nextKey = toprovide[0]
-				toprovide = toprovide[1:]
+			if len(toProvide) > 0 {
+				nextKey = toProvide[0]
+				toProvide = toProvide[1:]
 			} else {
 				keysOut = nil
 			}

--- a/exchange/bitswap/workers.go
+++ b/exchange/bitswap/workers.go
@@ -6,6 +6,7 @@ import (
 	inflect "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/chuckpreslar/inflect"
 	process "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/goprocess"
 	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
+	u "github.com/jbenet/go-ipfs/util"
 )
 
 func (bs *Bitswap) startWorkers(px process.Process, ctx context.Context) {
@@ -22,6 +23,10 @@ func (bs *Bitswap) startWorkers(px process.Process, ctx context.Context) {
 	// Start up a worker to manage periodically resending our wantlist out to peers
 	px.Go(func(px process.Process) {
 		bs.rebroadcastWorker(ctx)
+	})
+
+	px.Go(func(px process.Process) {
+		bs.provideCollector(ctx)
 	})
 
 	// Spawn up multiple workers to handle incoming blocks
@@ -58,15 +63,60 @@ func (bs *Bitswap) taskWorker(ctx context.Context) {
 func (bs *Bitswap) provideWorker(ctx context.Context) {
 	for {
 		select {
+		case k, ok := <-bs.provideKeys:
+			if !ok {
+				log.Debug("provideKeys channel closed")
+				return
+			}
+			ctx, _ := context.WithTimeout(ctx, provideTimeout)
+			err := bs.network.Provide(ctx, k)
+			if err != nil {
+				log.Error(err)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (bs *Bitswap) provideCollector(ctx context.Context) {
+	defer close(bs.provideKeys)
+	var toprovide []u.Key
+	var nextKey u.Key
+
+	select {
+	case blk, ok := <-bs.newBlocks:
+		if !ok {
+			log.Debug("newBlocks channel closed")
+			return
+		}
+		nextKey = blk.Key()
+	case <-ctx.Done():
+		return
+	}
+
+	for {
+		select {
 		case blk, ok := <-bs.newBlocks:
 			if !ok {
 				log.Debug("newBlocks channel closed")
 				return
 			}
-			ctx, _ := context.WithTimeout(ctx, provideTimeout)
-			err := bs.network.Provide(ctx, blk.Key())
-			if err != nil {
-				log.Error(err)
+			toprovide = append(toprovide, blk.Key())
+		case bs.provideKeys <- nextKey:
+			if len(toprovide) > 0 {
+				nextKey = toprovide[0]
+				toprovide = toprovide[1:]
+			} else {
+				select {
+				case blk, ok := <-bs.newBlocks:
+					if !ok {
+						return
+					}
+					nextKey = blk.Key()
+				case <-ctx.Done():
+					return
+				}
 			}
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
This PR grabs all the keys that need to be provided and consolidates them into a single buffer of keys. In doing so, it releases the reference to the block being provided, allowing the GC to remove it from memory, and also preventing the HasBlock goroutines from building up blocking on provide sends.