### PR TITLE
Ipns/refactor unixfs

### DIFF
--- a/importer/helpers/dagbuilder.go
+++ b/importer/helpers/dagbuilder.go
@@ -78,6 +78,11 @@ func (db *DagBuilderHelper) Next() []byte {
 	return d
 }
 
+// GetDagServ returns the dagservice object this Helper is using
+func (db *DagBuilderHelper) GetDagServ() dag.DAGService {
+	return db.dserv
+}
+
 // FillNodeLayer will add datanodes as children to the give node until
 // at most db.indirSize ndoes are added
 //
@@ -86,7 +91,7 @@ func (db *DagBuilderHelper) FillNodeLayer(node *UnixfsNode) error {
 
 	// while we have room AND we're not done
 	for node.NumChildren() < db.maxlinks && !db.Done() {
-		child := NewUnixfsNode()
+		child := NewUnixfsBlock()
 
 		if err := db.FillNodeWithData(child); err != nil {
 			return err
@@ -110,7 +115,7 @@ func (db *DagBuilderHelper) FillNodeWithData(node *UnixfsNode) error {
 		return ErrSizeLimitExceeded
 	}
 
-	node.setData(data)
+	node.SetData(data)
 	return nil
 }
 

--- a/unixfs/format_test.go
+++ b/unixfs/format_test.go
@@ -7,15 +7,16 @@ import (
 	pb "github.com/jbenet/go-ipfs/unixfs/pb"
 )
 
-func TestMultiBlock(t *testing.T) {
-	mbf := new(MultiBlock)
+func TestFSNode(t *testing.T) {
+	fsn := new(FSNode)
+	fsn.Type = TFile
 	for i := 0; i < 15; i++ {
-		mbf.AddBlockSize(100)
+		fsn.AddBlockSize(100)
 	}
 
-	mbf.Data = make([]byte, 128)
+	fsn.Data = make([]byte, 128)
 
-	b, err := mbf.GetBytes()
+	b, err := fsn.GetBytes()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This refactors the unixfs 'MultiBlock' object into a more general 'FSNode' object and adds some methods to the related code making it easier to work with.

This is PR number 2 of the ipns set