### PR TITLE
context: Always call returned cancel funcs

### DIFF
--- a/core/commands/id.go
+++ b/core/commands/id.go
@@ -7,10 +7,8 @@ import (
 	"errors"
 	"io"
 	"strings"
-	"time"
 
 	b58 "github.com/jbenet/go-ipfs/Godeps/_workspace/src/github.com/jbenet/go-base58"
-	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 
 	cmds "github.com/jbenet/go-ipfs/commands"
 	core "github.com/jbenet/go-ipfs/core"
@@ -81,14 +79,13 @@ ipfs id supports the format option for output with the following keys:
 			return
 		}
 
-		ctx, _ := context.WithTimeout(context.TODO(), time.Second*5)
 		// TODO handle offline mode with polymorphism instead of conditionals
 		if !node.OnlineMode() {
 			res.SetError(errors.New(offlineIdErrorMessage), cmds.ErrClient)
 			return
 		}
 
-		p, err := node.Routing.FindPeer(ctx, id)
+		p, err := node.Routing.FindPeer(req.Context().Context, id)
 		if err == kb.ErrLookupFailure {
 			res.SetError(errors.New(offlineIdErrorMessage), cmds.ErrClient)
 			return

--- a/core/commands/ping.go
+++ b/core/commands/ping.go
@@ -126,7 +126,8 @@ func pingPeer(ctx context.Context, n *core.IpfsNode, pid peer.ID, numPings int) 
 				Text: fmt.Sprintf("Looking up peer %s", pid.Pretty()),
 			}
 
-			ctx, _ := context.WithTimeout(ctx, kPingTimeout)
+			ctx, cancel := context.WithTimeout(ctx, kPingTimeout)
+			defer cancel()
 			p, err := n.Routing.FindPeer(ctx, pid)
 			if err != nil {
 				outChan <- &PingResult{Text: fmt.Sprintf("Peer lookup error: %s", err)}
@@ -147,7 +148,8 @@ func pingPeer(ctx context.Context, n *core.IpfsNode, pid peer.ID, numPings int) 
 			default:
 			}
 
-			ctx, _ := context.WithTimeout(ctx, kPingTimeout)
+			ctx, cancel := context.WithTimeout(ctx, kPingTimeout)
+			defer cancel()
 			took, err := n.Routing.Ping(ctx, pid)
 			if err != nil {
 				log.Debugf("Ping error: %s", err)

--- a/core/corenet/net.go
+++ b/core/corenet/net.go
@@ -54,7 +54,8 @@ func Listen(nd *core.IpfsNode, protocol string) (*ipfsListener, error) {
 }
 
 func Dial(nd *core.IpfsNode, p peer.ID, protocol string) (net.Stream, error) {
-	ctx, _ := context.WithTimeout(nd.Context(), time.Second*30)
+	ctx, cancel := context.WithTimeout(nd.Context(), time.Second*30)
+	defer cancel()
 	err := nd.PeerHost.Connect(ctx, peer.PeerInfo{ID: p})
 	if err != nil {
 		return nil, err

--- a/diagnostics/diag.go
+++ b/diagnostics/diag.go
@@ -14,12 +14,12 @@ import (
 
 	ggio "github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/gogoprotobuf/io"
 	"github.com/jbenet/go-ipfs/Godeps/_workspace/src/code.google.com/p/goprotobuf/proto"
-	ctxutil "github.com/jbenet/go-ipfs/util/ctx"
 	context "github.com/jbenet/go-ipfs/Godeps/_workspace/src/golang.org/x/net/context"
 	host "github.com/jbenet/go-ipfs/p2p/host"
 	inet "github.com/jbenet/go-ipfs/p2p/net"
 	peer "github.com/jbenet/go-ipfs/p2p/peer"
 	protocol "github.com/jbenet/go-ipfs/p2p/protocol"
+	ctxutil "github.com/jbenet/go-ipfs/util/ctx"
 
 	pb "github.com/jbenet/go-ipfs/diagnostics/internal/pb"
 	util "github.com/jbenet/go-ipfs/util"
@@ -138,7 +138,8 @@ func newID() string {
 // GetDiagnostic runs a diagnostics request across the entire network
 func (d *Diagnostics) GetDiagnostic(timeout time.Duration) ([]*DiagInfo, error) {
 	log.Debug("Getting diagnostic.")
-	ctx, _ := context.WithTimeout(context.TODO(), timeout)
+	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+	defer cancel()
 
 	diagID := newID()
 	d.diagLock.Lock()

--- a/merkledag/merkledag.go
+++ b/merkledag/merkledag.go
@@ -88,7 +88,8 @@ func (n *dagService) Get(k u.Key) (*Node, error) {
 		return nil, fmt.Errorf("dagService is nil")
 	}
 
-	ctx, _ := context.WithTimeout(context.TODO(), time.Minute)
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Minute)
+	defer cancel()
 	// we shouldn't use an arbitrary timeout here.
 	// since Get doesnt take in a context yet, we give a large upper bound.
 	// think of an http request. we want it to go on as long as the client requests it.

--- a/namesys/publisher.go
+++ b/namesys/publisher.go
@@ -60,9 +60,11 @@ func (p *ipnsPublisher) Publish(ctx context.Context, k ci.PrivKey, value u.Key) 
 	nameb := u.Hash(pkbytes)
 	namekey := u.Key("/pk/" + string(nameb))
 
+	timectx, cancel := context.WithDeadline(ctx, time.Now().Add(time.Second*10))
+	defer cancel()
+
 	log.Debugf("Storing pubkey at: %s", namekey)
 	// Store associated public key
-	timectx, _ := context.WithDeadline(ctx, time.Now().Add(time.Second*10))
 	err = p.routing.PutValue(timectx, namekey, pkbytes)
 	if err != nil {
 		return err

--- a/p2p/net/swarm/swarm_dial.go
+++ b/p2p/net/swarm/swarm_dial.go
@@ -227,8 +227,9 @@ func (s *Swarm) gatedDialAttempt(ctx context.Context, p peer.ID) (*Conn, error) 
 		// if it succeeds, dial will add the conn to the swarm itself.
 
 		defer log.EventBegin(ctx, "swarmDialAttemptStart", logdial).Done()
-		ctxT, _ := context.WithTimeout(ctx, s.dialT)
+		ctxT, cancel := context.WithTimeout(ctx, s.dialT)
 		conn, err := s.dial(ctxT, p)
+		cancel()
 		s.dsync.Unlock(p)
 		log.Debugf("dial end %s", conn)
 		if err != nil {

--- a/pin/pin.go
+++ b/pin/pin.go
@@ -172,7 +172,9 @@ func (p *pinner) pinIndirectRecurse(node *mdag.Node) error {
 }
 
 func (p *pinner) pinLinks(node *mdag.Node) error {
-	ctx, _ := context.WithTimeout(context.Background(), time.Second*60)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	defer cancel()
+
 	for _, ng := range p.dserv.GetDAG(ctx, node) {
 		subnode, err := ng.Get()
 		if err != nil {

--- a/routing/dht/dht.go
+++ b/routing/dht/dht.go
@@ -357,11 +357,12 @@ func (dht *IpfsDHT) PingRoutine(t time.Duration) {
 			rand.Read(id)
 			peers := dht.routingTable.NearestPeers(kb.ConvertKey(u.Key(id)), 5)
 			for _, p := range peers {
-				ctx, _ := context.WithTimeout(dht.Context(), time.Second*5)
+				ctx, cancel := context.WithTimeout(dht.Context(), time.Second*5)
 				_, err := dht.Ping(ctx, p)
 				if err != nil {
 					log.Debugf("Ping error: %s", err)
 				}
+				cancel()
 			}
 		case <-dht.Closing():
 			return

--- a/routing/dht/records.go
+++ b/routing/dht/records.go
@@ -28,7 +28,8 @@ func (dht *IpfsDHT) getPublicKeyOnline(ctx context.Context, p peer.ID) (ci.PubKe
 	}
 
 	// ok, try the node itself. if they're overwhelmed or slow we can move on.
-	ctxT, _ := ctxutil.WithDeadlineFraction(ctx, 0.3)
+	ctxT, cancelFunc := ctxutil.WithDeadlineFraction(ctx, 0.3)
+	defer cancelFunc()
 	if pk, err := dht.getPublicKeyFromNode(ctx, p); err == nil {
 		return pk, nil
 	}

--- a/unixfs/tar/reader.go
+++ b/unixfs/tar/reader.go
@@ -86,7 +86,8 @@ func (r *Reader) writeToBuf(dagnode *mdag.Node, path string, depth int) {
 		}
 		r.flush()
 
-		ctx, _ := context.WithTimeout(context.TODO(), time.Second*60)
+		ctx, cancel := context.WithTimeout(context.TODO(), time.Second*60)
+		defer cancel()
 
 		for i, ng := range r.dag.GetDAG(ctx, dagnode) {
 			childNode, err := ng.Get()


### PR DESCRIPTION
This PR follows up on #822.

- [x] [core/commands/id.go](https://github.com/jbenet/go-ipfs/blob/master/core/commands/id.go):	`ctx, _ := context.WithTimeout(context.TODO(), time.Second*5)`
- [x] [core/commands/ping.go](https://github.com/jbenet/go-ipfs/blob/master/core/commands/ping.go):	`ctx, _ := context.WithTimeout(ctx, kPingTimeout)`
- [x] [core/commands/ping.go](https://github.com/jbenet/go-ipfs/blob/master/core/commands/ping.go):	`ctx, _ := context.WithTimeout(ctx, kPingTimeout)`
- [x] [core/corenet/net.go](https://github.com/jbenet/go-ipfs/blob/master/core/corenet/net.go):	`ctx, _ := context.WithTimeout(nd.Context(), time.Second*30)`
- [x] [diagnostics/diag.go](https://github.com/jbenet/go-ipfs/blob/master/diagnostics/diag.go):	`ctx, _ := context.WithTimeout(context.TODO(), timeout)`
- [x] [exchange/bitswap/bitswap.go](https://github.com/jbenet/go-ipfs/blob/master/exchange/bitswap/bitswap.go):	`child, _ := context.WithTimeout(ctx, providerRequestTimeout)`
- [x] [exchange/bitswap/bitswap.go](https://github.com/jbenet/go-ipfs/blob/master/exchange/bitswap/bitswap.go):	`hasBlockCtx, _ := context.WithTimeout(ctx, hasBlockTimeout)`
- [x] [merkledag/merkledag.go](https://github.com/jbenet/go-ipfs/blob/master/merkledag/merkledag.go):	`ctx, _ := context.WithTimeout(context.TODO(), time.Minute)`
- [x] [namesys/publisher.go](https://github.com/jbenet/go-ipfs/blob/master/namesys/publisher.go):	`timectx, _ := context.WithDeadline(ctx, time.Now().Add(time.Second*10))`
- [x] [p2p/net/swarm/swarm_dial.go](https://github.com/jbenet/go-ipfs/blob/master/p2p/net/swarm/swarm_dial.go):	`ctxT, _ := context.WithTimeout(ctx, s.dialT)`
- [x] [pin/pin.go](https://github.com/jbenet/go-ipfs/blob/master/pin/pin.go):	`ctx, _ := context.WithTimeout(context.Background(), time.Second*60)`
- [x] [routing/dht/dht.go](https://github.com/jbenet/go-ipfs/blob/master/routing/dht/dht.go):	`ctx, _ := context.WithTimeout(dht.Context(), time.Second*5)`
- [x] [unixfs/tar/reader.go](https://github.com/jbenet/go-ipfs/blob/master/unixfs/tar/reader.go):	`ctx, _ := context.WithTimeout(context.TODO(), time.Second*60)`