### PR TITLE
t0045: style cleanup and add missing &&

### DIFF
--- a/test/sharness/t0045-ls.sh
+++ b/test/sharness/t0045-ls.sh
@@ -11,56 +11,56 @@ test_description="Test ls command"
 test_init_ipfs
 
 test_expect_success "'ipfs add -r testData' succeeds" '
-	mkdir testData testData/d1 testData/d2 && \
-	echo "test" > testData/f1 && \
-	echo "data" > testData/f2 && \
-	echo "hello" > testData/d1/a && \
-	random 128 42 > testData/d1/128 && \
-	echo "world" > testData/d2/a && \
-	random 1024 42 > testData/d2/1024 && \
-	ipfs add -r testData > actual_add
+	mkdir testData testData/d1 testData/d2 &&
+	echo "test" >testData/f1 &&
+	echo "data" >testData/f2 &&
+	echo "hello" >testData/d1/a &&
+	random 128 42 >testData/d1/128 &&
+	echo "world" >testData/d2/a &&
+	random 1024 42 >testData/d2/1024 &&
+	ipfs add -r testData >actual_add
 '
 
 test_expect_success "'ipfs add' output looks good" '
-	cat << EOF > expected_add
-added QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe testData/d1/128
-added QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN testData/d1/a
-added QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss testData/d1
-added QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd testData/d2/1024
-added QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL testData/d2/a
-added QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy testData/d2
-added QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH testData/f1
-added QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M testData/f2
-added QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj testData
-EOF
-	test $(diff actual_add expected_add | wc -l) -eq 0
+	cat <<-\EOF >expected_add &&
+		added QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe testData/d1/128
+		added QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN testData/d1/a
+		added QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss testData/d1
+		added QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd testData/d2/1024
+		added QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL testData/d2/a
+		added QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy testData/d2
+		added QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH testData/f1
+		added QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M testData/f2
+		added QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj testData
+	EOF
+	test_cmp expected_add actual_add
 '
 
 test_expect_success "'ipfs ls <three dir hashes>' succeeds" '
-	ipfs ls QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss > actual_ls
+	ipfs ls QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss >actual_ls
 '
 
 test_expect_success "'ipfs ls <three dir hashes>' output looks good" '
-	cat << EOF > expected_ls
-QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj:
-Hash                                           Size Name 
-QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss 246  d1/  
-QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy 1143 d2/  
-QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH 13   f1   
-QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M 13   f2   
+	cat <<-\EOF >expected_ls &&
+		QmfNy183bXiRVyrhyWtq3TwHn79yHEkiAGFr18P7YNzESj:
+		Hash                                           Size Name 
+		QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss 246  d1/  
+		QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy 1143 d2/  
+		QmeomffUNfmQy76CQGy9NdmqEnnHU9soCexBnGU3ezPHVH 13   f1   
+		QmNtocSs7MoDkJMc1RkyisCSKvLadujPsfJfSdJ3e1eA1M 13   f2   
 
-QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy:
-Hash                                           Size Name 
-QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1035 1024 
-QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL 14   a    
+		QmR3jhV4XpxxPjPT3Y8vNnWvWNvakdcT3H6vqpRBsX1MLy:
+		Hash                                           Size Name 
+		QmbQBUSRL9raZtNXfpTDeaxQapibJEG6qEY8WqAN22aUzd 1035 1024 
+		QmaRGe7bVmVaLmxbrMiVNXqW4pRNNp3xq7hFtyRKA3mtJL 14   a    
 
-QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
-Hash                                           Size Name 
-QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 139  128  
-QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN 14   a    
+		QmSix55yz8CzWXf5ZVM9vgEvijnEeeXiTSarVtsqiiCJss:
+		Hash                                           Size Name 
+		QmQNd6ubRXaNG6Prov8o6vk3bn6eWsj9FxLGrAVDUAGkGe 139  128  
+		QmZULkCELmmk5XNfCgTnCyFgAVxBRBXyDHGGMVoLFLiXEN 14   a    
 
-EOF
-	test $(diff actual_ls expected_ls | wc -l) -eq 0
+	EOF
+	test_cmp expected_ls actual_ls
 '
 
 test_done


### PR DESCRIPTION
This makes the following changes:

- remove some superfluous \ at the end of some lines
- use `cat <<-\EOF >expected` to ignore the starting tabs
  in the here document
- add missing && after some `cat`
- use test_cmp to compare files

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>