### PR TITLE
`gc` is actually `repo gc`, reflect in docs

### DIFF
--- a/core/commands/root.go
+++ b/core/commands/root.go
@@ -42,7 +42,7 @@ ADVANCED COMMANDS
     mount         Mount an ipfs read-only mountpoint
     name          Publish or resolve IPNS names
     pin           Pin objects to local storage
-    gc            Garbage collect unpinned objects
+    repo gc       Garbage collect unpinned objects
 
 NETWORK COMMANDS
 


### PR DESCRIPTION
not exactly elegant, but fixes #871 in the short term. in the mid term, unless more `repo` commands show up, i suggest just replacing `repo gc` simply by `gc`.