### PR TITLE
ls: introduce specific output types 

### DIFF
--- a/core/commands/object.go
+++ b/core/commands/object.go
@@ -28,6 +28,16 @@ type Node struct {
 	Data  string
 }
 
+type Link struct {
+	Name, Hash string
+	Size       uint64
+}
+
+type Object struct {
+	Hash  string
+	Links []Link
+}
+
 var ObjectCmd = &cmds.Command{
 	Helptext: cmds.HelpText{
 		Tagline: "Interact with ipfs objects",
@@ -123,7 +133,10 @@ multihash.
 			object := res.Output().(*Object)
 			var buf bytes.Buffer
 			w := tabwriter.NewWriter(&buf, 1, 2, 1, ' ', 0)
-			marshalLinks(w, object.Links)
+			fmt.Fprintln(w, "Hash\tSize\tName\t")
+			for _, link := range object.Links {
+				fmt.Fprintf(w, "%s\t%v\t%s\t\n", link.Hash, link.Size, link.Name)
+			}
 			w.Flush()
 			return &buf, nil
 		},


### PR DESCRIPTION
This PR removes `IsDir` from the object plumbing commands, as discussed in #907.

- [x] It introduces new `LsLink` type, which is like the old `Link` but with a `Type` field.

Maybe this can be carried over to the latter `unixfs` specific commands?

- [x] It removes `func marshalLinks()`.

They were only used by the marshalers in `ipfs ls` and `ipfs object links`. SInce they operate on different types now, there is no reuse that makes it useful.
