### PR TITLE
ipfs object put: return error if object is empty

### DIFF
--- a/core/commands/object.go
+++ b/core/commands/object.go
@@ -379,6 +379,9 @@ func objectGet(n *core.IpfsNode, fpath path.Path) (*dag.Node, error) {
 	return dagnode, nil
 }
 
+// ErrEmptyNode is returned when the input to 'ipfs object put' contains no data
+var ErrEmptyNode = errors.New("no data or links in this node")
+
 // objectPut takes a format option, serializes bytes from stdin and updates the dag with that data
 func objectPut(n *core.IpfsNode, input io.Reader, encoding string) (*Object, error) {
 	var (
@@ -402,6 +405,12 @@ func objectPut(n *core.IpfsNode, input io.Reader, encoding string) (*Object, err
 		err = json.Unmarshal(data, node)
 		if err != nil {
 			return nil, err
+		}
+
+		// check that we have data in the Node to add
+		// otherwise we will add the empty object without raising an error
+		if node.Data == "" && len(node.Links) == 0 {
+			return nil, ErrEmptyNode
 		}
 
 		dagnode, err = deserializeNode(node)

--- a/test/sharness/t0051-object-data/brokenPut.json
+++ b/test/sharness/t0051-object-data/brokenPut.json
@@ -1,0 +1,5 @@
+{
+	"this": "should",
+	"return": "an",
+	"error":"not valid dag object"
+}

--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -82,5 +82,16 @@ test_expect_success "'ipfs object put' from stdin (pb) output looks good" '
 	test_cmp expected_putStdinOut actual_putPbStdinOut
 '
 
+test_expect_success "'ipfs object put broken.json' should fail" '
+  test_expect_code 1 ipfs object put ../t0051-object-data/brokenPut.json 2>actual_putBrokenErr >actual_putBroken
+'
+
+test_expect_success "'ipfs object put broken.hjson' output looks good" '
+  touch expected_putBroken &&
+  printf "Error: no data or links in this node\n" > expected_putBrokenErr &&
+  test_cmp expected_putBroken actual_putBroken &&
+  test_cmp expected_putBrokenErr actual_putBrokenErr
+'
+
 
 test_done


### PR DESCRIPTION
This should fix #883.

I added a check after `json.Unmarshall()` to see if the `Data` field __and__ the `Links` slice are empty.

Ideally we could just compare a struct to it's zero value but with the `Links` slice, this doesn't work. (http://play.golang.org/p/mx6qhEM6SC)

