### PR TITLE
test/bin: fix continueyn on Linux

### DIFF
--- a/test/bin/continueyn
+++ b/test/bin/continueyn
@@ -5,9 +5,9 @@
 # if not a terminal, exit 0 (yes!)
 test -t 1 || exit 0
 
-read -p "continue? [y/N] "
+read -p "continue? [y/N] " REPLY
 echo
-if [[ $REPLY =~ ^[Yy] ]]; then
-    exit 0
-fi
-exit 1
+case "$REPLY" in
+    [Yy]*) exit 0 ;;
+    *) exit 1 ;;
+esac


### PR DESCRIPTION
It looks like there were two problems:

- "read" command probably needs the name of the variable
  it reads into

- [[ didn't work

This might be because on Linux /bin/sh is sometimes not
bash. For example on Ubuntu it is a symlink to dash.

This should fix issue #927 

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>