### PR TITLE
Fixes issue #924

### DIFF
--- a/core/corehttp/gateway_handler.go
+++ b/core/corehttp/gateway_handler.go
@@ -174,15 +174,7 @@ func (i *gatewayHandler) getHandler(w http.ResponseWriter, r *http.Request) {
 
 	nd, p, err := i.ResolvePath(ctx, urlPath)
 	if err != nil {
-		if err == routing.ErrNotFound {
-			w.WriteHeader(http.StatusNotFound)
-		} else if err == context.DeadlineExceeded {
-			w.WriteHeader(http.StatusRequestTimeout)
-		} else {
-			w.WriteHeader(http.StatusBadRequest)
-		}
-
-		w.Write([]byte(err.Error()))
+		webError(w, "Path Resolve error", err, http.StatusBadRequest)
 		return
 	}
 

--- a/core/corehttp/gateway_test.go
+++ b/core/corehttp/gateway_test.go
@@ -91,7 +91,7 @@ func TestGatewayGet(t *testing.T) {
 		{"localhost:5001", "/", http.StatusNotFound, "404 page not found\n"},
 		{"localhost:5001", "/" + k, http.StatusNotFound, "404 page not found\n"},
 		{"localhost:5001", "/ipfs/" + k, http.StatusOK, "fnord"},
-		{"localhost:5001", "/ipns/nxdomain.example.com", http.StatusBadRequest, namesys.ErrResolveFailed.Error()},
+		{"localhost:5001", "/ipns/nxdomain.example.com", http.StatusBadRequest, "Path Resolve error: " + namesys.ErrResolveFailed.Error()},
 		{"localhost:5001", "/ipns/example.com", http.StatusOK, "fnord"},
 		{"example.com", "/", http.StatusOK, "fnord"},
 	} {


### PR DESCRIPTION
Simplifies web error handling slightly for the getHandler, and fixes the issue of sending a 404 on a failed path resolve.