### PR TITLE
windows

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -195,7 +195,7 @@
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-reuseport",
-			"Rev": "096958438ae3683c9f3c8ae0f7139b5ce600e6a8"
+			"Rev": "c71a70ef82a7acb87ad77704de1be7b9cd776a55"
 		},
 		{
 			"ImportPath": "github.com/jbenet/go-sockaddr/net",

--- a/Godeps/_workspace/src/github.com/jbenet/go-reuseport/available_unix.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-reuseport/available_unix.go
@@ -1,4 +1,5 @@
 // +build darwin freebsd dragonfly netbsd openbsd linux
+
 package reuseport
 
 import (

--- a/Godeps/_workspace/src/github.com/jbenet/go-reuseport/impl_windows.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-reuseport/impl_windows.go
@@ -1,13 +1,19 @@
 package reuseport
 
-import (
-	"net"
-)
+import "net"
 
 // TODO. for now, just pass it over to net.Listen/net.Dial
 
 func listen(network, address string) (net.Listener, error) {
 	return net.Listen(network, address)
+}
+
+func listenPacket(netw, laddr string) (net.PacketConn, error) {
+	return net.ListenPacket(netw, laddr)
+}
+
+func listenStream(netw, addr string) (net.Listener, error) {
+	return listen(netw, addr)
 }
 
 func dial(dialer net.Dialer, network, address string) (net.Conn, error) {

--- a/Godeps/_workspace/src/github.com/jbenet/go-reuseport/opts_posix.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-reuseport/opts_posix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris windows
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package reuseport
 

--- a/Godeps/_workspace/src/github.com/jbenet/go-reuseport/poll/poll_darwin_386.go
+++ b/Godeps/_workspace/src/github.com/jbenet/go-reuseport/poll/poll_darwin_386.go
@@ -1,5 +1,3 @@
-// +build darwin,amd64 freebsd dragonfly netbsd openbsd
-
 package poll
 
 import (
@@ -21,7 +19,7 @@ func New(fd int) (p *Poller, err error) {
 	}
 
 	p.event = syscall.Kevent_t{
-		Ident:  uint64(fd),
+		Ident:  uint32(fd),
 		Filter: syscall.EVFILT_WRITE,
 		Flags:  syscall.EV_ADD | syscall.EV_ENABLE | syscall.EV_ONESHOT,
 		Fflags: 0,


### PR DESCRIPTION
This updates `go-reuseport` to get windows compilation.

To compile on windows, you need to disable fuse by compiling with `go build -tags nofuse`.


There are a number of other outstanding issues:

- [ ] when build for windows, `github.com/cheggaaa/pb` depends on `github.com/olekukonko/ts` which is currently not vendored
- [ ] shutdown sometimes leaves `daemon.lock` sitting around  and spits out `ERROR ipnsfs <autogenerated>:24: leveldb: closed`
- [ ] sometimes `blockservice.test.exe` or `dht.test.exe` hang during `go test -tags nofuse ./...` and need to be killed manually
- [ ] some test failures- runs: [1](http://gateway.ipfs.io/ipfs/QmbUzbTg2n3y5ununCCA1Skzot5g2qT6rdSBa2Jxaq3aLi) [2](http://gateway.ipfs.io/ipfs/QmTarpiJoJ6soZQJbQnccN6WcjpxMd5iasz3H4WzEjaYKC)
- [ ] some weird inconsistency between running in `cmd.exe` and `bash.exe` from git for windows

And I'm sure there is more. My tests are from a windows 7 QemuVM with a flacky VDE/SlirpDHCP network. I welcome every native windows user willing to test this with open arms.