### PR TITLE
Fix a mild race condition in `mount_darwin.go`

### DIFF
--- a/Godeps/_workspace/src/bazil.org/fuse/mount_darwin.go
+++ b/Godeps/_workspace/src/bazil.org/fuse/mount_darwin.go
@@ -89,7 +89,7 @@ func callMount(dir string, conf *MountConfig, f *os.File, ready chan<- struct{},
 		return err
 	}
 	go func() {
-		err = cmd.Wait()
+		err := cmd.Wait()
 		if err != nil {
 			if buf.Len() > 0 {
 				output := buf.Bytes()


### PR DESCRIPTION
Found in the process of fixing #945.

It doesn't solve #945, but it solves the race conditions that I've mentioned there.