### PR TITLE
t0051: test ipfs object online as well as offline

### DIFF
--- a/test/sharness/t0051-object.sh
+++ b/test/sharness/t0051-object.sh
@@ -10,88 +10,98 @@ test_description="Test object command"
 
 test_init_ipfs
 
-test_expect_success "'ipfs add testData' succeeds" '
-	printf "Hello Mars" >expected_in &&
-	ipfs add expected_in >actual_Addout
-'
+test_object_cmd() {
 
-test_expect_success "'ipfs add testData' output looks good" '
-	HASH="QmWkHFpYBZ9mpPRreRbMhhYWXfUhBAue3JkbbpFqwowSRb" &&
-	echo "added $HASH expected_in" >expected_Addout &&
-	test_cmp expected_Addout actual_Addout
-'
+	test_expect_success "'ipfs add testData' succeeds" '
+		printf "Hello Mars" >expected_in &&
+		ipfs add expected_in >actual_Addout
+	'
+	
+	test_expect_success "'ipfs add testData' output looks good" '
+		HASH="QmWkHFpYBZ9mpPRreRbMhhYWXfUhBAue3JkbbpFqwowSRb" &&
+		echo "added $HASH expected_in" >expected_Addout &&
+		test_cmp expected_Addout actual_Addout
+	'
+	
+	test_expect_success "'ipfs object get' succeeds" '
+		ipfs object get $HASH >actual_getOut
+	'
+	
+	test_expect_success "'ipfs object get' output looks good" '
+		test_cmp ../t0051-object-data/expected_getOut actual_getOut
+	'
+	
+	test_expect_success "'ipfs object stat' succeeds" '
+		ipfs object stat $HASH >actual_stat
+	'
+	
+	test_expect_success "'ipfs object get' output looks good" '
+		echo "NumLinks: 0" > expected_stat &&
+		echo "BlockSize: 18" >> expected_stat &&
+		echo "LinksSize: 2" >> expected_stat &&
+		echo "DataSize: 16" >> expected_stat &&
+		echo "CumulativeSize: 18" >> expected_stat &&
+		test_cmp expected_stat actual_stat
+	'
+	
+	test_expect_success "'ipfs object put file.json' succeeds" '
+		ipfs object put  ../t0051-object-data/testPut.json > actual_putOut
+	'
+	
+	test_expect_success "'ipfs object put file.json' output looks good" '
+		HASH="QmUTSAdDi2xsNkDtLqjFgQDMEn5di3Ab9eqbrt4gaiNbUD" &&
+		printf "added $HASH" > expected_putOut &&
+		test_cmp expected_putOut actual_putOut
+	'
+	
+	test_expect_success "'ipfs object put file.pb' succeeds" '
+		ipfs object put --inputenc=protobuf ../t0051-object-data/testPut.pb > actual_putOut
+	'
+	
+	test_expect_success "'ipfs object put file.pb' output looks good" '
+		HASH="QmUTSAdDi2xsNkDtLqjFgQDMEn5di3Ab9eqbrt4gaiNbUD" &&
+		printf "added $HASH" > expected_putOut &&
+		test_cmp expected_putOut actual_putOut
+	'
+	
+	test_expect_success "'ipfs object put' from stdin succeeds" '
+		cat ../t0051-object-data/testPut.json | ipfs object put > actual_putStdinOut
+	'
+	
+	test_expect_success "'ipfs object put' from stdin output looks good" '
+		HASH="QmUTSAdDi2xsNkDtLqjFgQDMEn5di3Ab9eqbrt4gaiNbUD" &&
+		printf "added $HASH" > expected_putStdinOut &&
+		test_cmp expected_putStdinOut actual_putStdinOut
+	'
+	
+	test_expect_success "'ipfs object put' from stdin (pb) succeeds" '
+		cat ../t0051-object-data/testPut.pb | ipfs object put --inputenc=protobuf > actual_putPbStdinOut
+	'
+	
+	test_expect_success "'ipfs object put' from stdin (pb) output looks good" '
+		HASH="QmUTSAdDi2xsNkDtLqjFgQDMEn5di3Ab9eqbrt4gaiNbUD" &&
+		printf "added $HASH" > expected_putStdinOut &&
+		test_cmp expected_putStdinOut actual_putPbStdinOut
+	'
+	
+	test_expect_success "'ipfs object put broken.json' should fail" '
+		test_expect_code 1 ipfs object put ../t0051-object-data/brokenPut.json 2>actual_putBrokenErr >actual_putBroken
+	'
+	
+	test_expect_success "'ipfs object put broken.hjson' output looks good" '
+		touch expected_putBroken &&
+		printf "Error: no data or links in this node\n" > expected_putBrokenErr &&
+		test_cmp expected_putBroken actual_putBroken &&
+		test_cmp expected_putBrokenErr actual_putBrokenErr
+	'
+}
 
-test_expect_success "'ipfs object get' succeeds" '
-	ipfs object get $HASH >actual_getOut
-'
+# should work offline
+test_object_cmd
 
-test_expect_success "'ipfs object get' output looks good" '
-	test_cmp ../t0051-object-data/expected_getOut actual_getOut
-'
-
-test_expect_success "'ipfs object stat' succeeds" '
-	ipfs object stat $HASH >actual_stat
-'
-
-test_expect_success "'ipfs object get' output looks good" '
-	echo "NumLinks: 0" > expected_stat &&
-	echo "BlockSize: 18" >> expected_stat &&
-	echo "LinksSize: 2" >> expected_stat &&
-	echo "DataSize: 16" >> expected_stat &&
-	echo "CumulativeSize: 18" >> expected_stat &&
-	test_cmp expected_stat actual_stat
-'
-
-test_expect_success "'ipfs object put file.json' succeeds" '
-	ipfs object put  ../t0051-object-data/testPut.json > actual_putOut
-'
-
-test_expect_success "'ipfs object put file.json' output looks good" '
-	HASH="QmUTSAdDi2xsNkDtLqjFgQDMEn5di3Ab9eqbrt4gaiNbUD" &&
-	printf "added $HASH" > expected_putOut &&
-	test_cmp expected_putOut actual_putOut
-'
-
-test_expect_success "'ipfs object put file.pb' succeeds" '
-	ipfs object put --inputenc=protobuf ../t0051-object-data/testPut.pb > actual_putOut
-'
-
-test_expect_success "'ipfs object put file.pb' output looks good" '
-	HASH="QmUTSAdDi2xsNkDtLqjFgQDMEn5di3Ab9eqbrt4gaiNbUD" &&
-	printf "added $HASH" > expected_putOut &&
-	test_cmp expected_putOut actual_putOut
-'
-
-test_expect_success "'ipfs object put' from stdin succeeds" '
-	cat ../t0051-object-data/testPut.json | ipfs object put > actual_putStdinOut
-'
-
-test_expect_success "'ipfs object put' from stdin output looks good" '
-	HASH="QmUTSAdDi2xsNkDtLqjFgQDMEn5di3Ab9eqbrt4gaiNbUD" &&
-	printf "added $HASH" > expected_putStdinOut &&
-	test_cmp expected_putStdinOut actual_putStdinOut
-'
-
-test_expect_success "'ipfs object put' from stdin (pb) succeeds" '
-	cat ../t0051-object-data/testPut.pb | ipfs object put --inputenc=protobuf > actual_putPbStdinOut
-'
-
-test_expect_success "'ipfs object put' from stdin (pb) output looks good" '
-	HASH="QmUTSAdDi2xsNkDtLqjFgQDMEn5di3Ab9eqbrt4gaiNbUD" &&
-	printf "added $HASH" > expected_putStdinOut &&
-	test_cmp expected_putStdinOut actual_putPbStdinOut
-'
-
-test_expect_success "'ipfs object put broken.json' should fail" '
-	test_expect_code 1 ipfs object put ../t0051-object-data/brokenPut.json 2>actual_putBrokenErr >actual_putBroken
-'
-
-test_expect_success "'ipfs object put broken.hjson' output looks good" '
-	touch expected_putBroken &&
-	printf "Error: no data or links in this node\n" > expected_putBrokenErr &&
-	test_cmp expected_putBroken actual_putBroken &&
-	test_cmp expected_putBrokenErr actual_putBrokenErr
-'
-
+# should work online
+test_launch_ipfs_daemon
+test_object_cmd
+test_kill_ipfs_daemon
 
 test_done


### PR DESCRIPTION
To do that the current tests are move inside a test_object_cmd() function. This function is then first called before running the daemon for offline tests and then after starting the daemon for online tests.

This will improve sharness test coverage (see issue #906, sharness test command coverage).

License: MIT
Signed-off-by: Christian Couder <chriscool@tuxfamily.org>